### PR TITLE
Added Circe Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ JWT Scala is divided in several sub-projects each targeting a specific use-case.
 |`jwt-play`|Play framework|[JwtSession](https://pauldijou.github.io/jwt-scala/samples/jwt-play)|[API](https://pauldijou.github.io/jwt-scala/api/latest/jwt-play)|
 |`jwt-json4s-native`|`json4s` Native implementation|[JwtJson4s](https://pauldijou.github.io/jwt-scala/samples/jwt-json4s)|[API](https://pauldijou.github.io/jwt-scala/api/latest/jwt-json4s)|
 |`jwt-json4s-jackson`|`json4s` Jackson implementation|[JwtJson4s](https://pauldijou.github.io/jwt-scala/samples/jwt-json4s)|[API](https://pauldijou.github.io/jwt-scala/api/latest/jwt-json4s)|
-
 |`jwt-circe`|`Circe`|[circe](https://pauldijou.github.io/jwt-scala/samples/jwt-circe)|[API](https://pauldijou.github.io/jwt-scala/api/latest/jwt-circe)|
 
 If you need a previous version of the Scaladoc API, check [the bottom of this page](https://pauldijou.github.io/jwt-scala/api/#old-apis)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ JWT Scala is divided in several sub-projects each targeting a specific use-case.
 |`jwt-json4s-native`|`json4s` Native implementation|[JwtJson4s](https://pauldijou.github.io/jwt-scala/samples/jwt-json4s)|[API](https://pauldijou.github.io/jwt-scala/api/latest/jwt-json4s)|
 |`jwt-json4s-jackson`|`json4s` Jackson implementation|[JwtJson4s](https://pauldijou.github.io/jwt-scala/samples/jwt-json4s)|[API](https://pauldijou.github.io/jwt-scala/api/latest/jwt-json4s)|
 
+|`jwt-circe`|`Circe`|[circe](https://pauldijou.github.io/jwt-scala/samples/jwt-circe)|[API](https://pauldijou.github.io/jwt-scala/api/latest/jwt-circe)|
+
 If you need a previous version of the Scaladoc API, check [the bottom of this page](https://pauldijou.github.io/jwt-scala/api/#old-apis)
 
 You can also check a [standalone Play application](https://github.com/pauldijou/jwt-scala/tree/master/examples/play-angular-standalone) using `jwt-play` and implementating a small REST API with authentication and admin role (include a UI too!).

--- a/build.sbt
+++ b/build.sbt
@@ -7,10 +7,10 @@ import Dependencies._
 import com.typesafe.sbt.SbtSite.SiteKeys._
 import com.typesafe.sbt.SbtGhPages.GhPagesKeys._
 
-val previousVersion = "0.4.1"
-val buildVersion = "0.4.2"
+val previousVersion = "0.4.0"
+val buildVersion = "0.4.1"
 
-addCommandAlias("testAll", ";coreCommonLegacy/test;coreCommonEdge/test;playJsonLegacy/test;playJsonEdge/test;json4sNativeLegacy/test;json4sNativeEdge/test;json4sJacksonLegacy/test;json4sJacksonEdge/test;playLegacy/test;playEdge/test")
+addCommandAlias("testAll", ";coreCommonLegacy/test;coreCommonEdge/test;playJsonLegacy/test;playJsonEdge/test;json4sNativeLegacy/test;json4sNativeEdge/test;json4sJacksonLegacy/test;json4sJacksonEdge/test;circeEdge/test;circeLegacy/test;playLegacy/test;playEdge/test")
 
 addCommandAlias("scaladoc", ";coreEdge/doc;playJsonEdge/doc;playEdge/doc;json4sNativeEdge/doc;scaladocScript")
 addCommandAlias("publish-doc", ";docs/makeSite;docs/ghpagesPushSite")

--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,8 @@ import Dependencies._
 import com.typesafe.sbt.SbtSite.SiteKeys._
 import com.typesafe.sbt.SbtGhPages.GhPagesKeys._
 
-val previousVersion = "0.4.0"
-val buildVersion = "0.4.1"
+val previousVersion = "0.4.1"
+val buildVersion = "0.4.2"
 
 addCommandAlias("testAll", ";coreCommonLegacy/test;coreCommonEdge/test;playJsonLegacy/test;playJsonEdge/test;json4sNativeLegacy/test;json4sNativeEdge/test;json4sJacksonLegacy/test;json4sJacksonEdge/test;playLegacy/test;playEdge/test")
 

--- a/build.sbt
+++ b/build.sbt
@@ -98,8 +98,8 @@ lazy val jwtScala = project.in(file("."))
   .settings(
     name := "jwt-scala"
   )
-  .aggregate(playEdge, playLegacy, json4sNativeLegacy, json4sNativeEdge, json4sJacksonLegacy, json4sJacksonEdge)
-  .dependsOn(playEdge, playLegacy, json4sNativeLegacy, json4sNativeEdge, json4sJacksonLegacy, json4sJacksonEdge)
+  .aggregate(playEdge, playLegacy, json4sNativeLegacy, json4sNativeEdge, json4sJacksonLegacy, json4sJacksonEdge, circeEdge, circeLegacy)
+  .dependsOn(playEdge, playLegacy, json4sNativeLegacy, json4sNativeEdge, json4sJacksonLegacy, json4sJacksonEdge, circeEdge, circeLegacy)
 
 lazy val docs = project.in(file("docs"))
   .settings(name := "jwt-docs")
@@ -183,6 +183,28 @@ lazy val playJsonEdge = project.in(file("json/play-json"))
   )
   .aggregate(jsonCommonEdge)
   .dependsOn(jsonCommonEdge % "compile->compile;test->test")
+
+
+lazy val circeLegacy = project.in(file("json/circe"))
+  .settings(publishSettings)
+  .settings(
+    name := "jwt-circe-legacy",
+    target <<= target(_ / "legacy"),
+    libraryDependencies ++= Seq(Libs.circeCore, Libs.circeGeneric, Libs.circeParse)
+  )
+  .aggregate(jsonCommonLegacy)
+  .dependsOn(jsonCommonLegacy % "compile->compile;test->test")
+
+lazy val circeEdge = project.in(file("json/circe"))
+  .settings(publishSettings)
+  .settings(
+    name := "jwt-circe",
+    target <<= target(_ / "edge"),
+    libraryDependencies ++= Seq(Libs.circeCore, Libs.circeGeneric, Libs.circeParse)
+  )
+  .aggregate(jsonCommonEdge)
+  .dependsOn(jsonCommonEdge % "compile->compile;test->test")
+
 
 lazy val json4sCommonLegacy = project.in(file("json/json4s-common"))
   .settings(publishSettings)

--- a/docs/src/main/tut/jwt-circe-jwt-json.md
+++ b/docs/src/main/tut/jwt-circe-jwt-json.md
@@ -1,0 +1,63 @@
+## JwtJson Object
+
+### Basic usage
+
+```tut
+
+import java.time.Instant
+import pdi.jwt.{JwtCirceJson, JwtAlgorithm, JwtClaim}
+
+val claim = JwtClaim(
+    expiration = Some(Instant.now.plusSeconds(157784760).getEpochSecond)
+  , issuedAt = Some(Instant.now.getEpochSecond)
+)
+val key = "secretKey"
+val algo = JwtAlgorithm.HS256
+
+val token = JwtCirceJson.encode(claim, key, algo)
+
+JwtCirceJson.decodeJson(token, key, Seq(JwtAlgorithm.HS256))
+JwtCirceJson.decode(token, key, Seq(JwtAlgorithm.HS256))
+```
+
+### Encoding
+
+```tut
+import java.time.Instant
+import io.circe._, syntax._, jawn.{parse => jawnParse}
+import cats.data.Xor
+import pdi.jwt.{JwtCirceJson, JwtAlgorithm, JwtClaim}
+
+val key = "secretKey"
+val algo = JwtAlgorithm.HS256
+
+val Xor.Right(claimJson) = jawnParse(s"""{"expires":${Instant.now.getEpochSecond}}""")
+val Xor.Right(header) = jawnParse( """{"typ":"JWT","alg":"HS256"}""")
+// From just the claim to all possible attributes
+JwtCirceJson.encode(claimJson)
+JwtCirceJson.encode(claimJson, key, algo)
+JwtCirceJson.encode(header, claimJson, key)
+```
+
+### Decoding
+
+```tut
+import java.time.Instant
+import pdi.jwt.{JwtCirceJson, JwtAlgorithm, JwtClaim}
+
+val claim = JwtClaim(
+    expiration = Some(Instant.now.plusSeconds(157784760).getEpochSecond)
+  , issuedAt = Some(Instant.now.getEpochSecond)
+)
+val key = "secretKey"
+val algo = JwtAlgorithm.HS256
+
+val token = JwtCirceJson.encode(claim, key, algo)
+
+// You can decode to JsObject
+JwtCirceJson.decodeJson(token, key, Seq(JwtAlgorithm.HS256))
+JwtCirceJson.decodeJsonAll(token, key, Seq(JwtAlgorithm.HS256))
+// Or to case classes
+JwtCirceJson.decode(token, key, Seq(JwtAlgorithm.HS256))
+JwtCirceJson.decodeAll(token, key, Seq(JwtAlgorithm.HS256))
+```

--- a/json/circe/src/main/scala/JwtCirceJson.scala
+++ b/json/circe/src/main/scala/JwtCirceJson.scala
@@ -1,0 +1,57 @@
+package pdi.jwt
+
+import io.circe._
+import io.circe.syntax._
+import io.circe.jawn.{parse => jawnParse}
+
+import pdi.jwt.exceptions.JwtNonStringException
+
+
+/**
+  * Implementation of `JwtCore` using `Json` from Circe.
+  */
+object JwtCirceJson extends JwtJsonCommon[Json] {
+  protected def parse(value: String): Json = jawnParse(value).toOption.get
+  protected def parseClaim(claim: String): JwtClaim = {
+    val cursor = parse(claim).hcursor
+    val fields = List("iss", "sub", "aud", "exp", "nbf", "iat", "jti")
+    val contentCursor = fields.foldLeft(cursor){(cursor, field) =>
+      val newCursor = cursor.downField(field).delete
+      if(newCursor.succeeded) newCursor.any
+      else cursor
+    }
+    JwtClaim(
+        content = contentCursor.top.asJson.noSpaces
+      , issuer = cursor.get[String]("iss").toOption
+      , subject = cursor.get[String]("sub").toOption
+      , audience = cursor.get[String]("aud").toOption
+      , expiration = cursor.get[Long]("exp").toOption
+      , notBefore = cursor.get[Long]("nbf").toOption
+      , issuedAt = cursor.get[Long]("iat").toOption
+      , jwtId = cursor.get[String]("jti").toOption
+    )
+  }
+
+  protected def stringify(value: Json): String = value.asJson.noSpaces
+
+  private def getAlg(cursor: HCursor): Option[JwtAlgorithm] = {
+    cursor.get[String]("alg").toOption.flatMap{
+      case "none" => None
+      case s if s == null => None
+      case s: String => Option(JwtAlgorithm.fromString(s))
+      case _ => throw new JwtNonStringException("alg")
+    }
+  }
+
+  protected def parseHeader(header: String): JwtHeader = {
+    val cursor = parse(header).hcursor
+    JwtHeader(
+        algorithm = getAlg(cursor)
+      , typ = cursor.get[String]("typ").toOption
+      , contentType = cursor.get[String]("cty").toOption
+    )
+  }
+
+  protected def getAlgorithm(header: Json): Option[JwtAlgorithm] = getAlg(header.hcursor)
+
+}

--- a/json/circe/src/main/scala/JwtCirceJson.scala
+++ b/json/circe/src/main/scala/JwtCirceJson.scala
@@ -14,8 +14,7 @@ object JwtCirceJson extends JwtJsonCommon[Json] {
   protected def parse(value: String): Json = jawnParse(value).toOption.get
   protected def parseClaim(claim: String): JwtClaim = {
     val cursor = parse(claim).hcursor
-    val fields = List("iss", "sub", "aud", "exp", "nbf", "iat", "jti")
-    val contentCursor = fields.foldLeft(cursor){(cursor, field) =>
+    val contentCursor = List("iss", "sub", "aud", "exp", "nbf", "iat", "jti").foldLeft(cursor){(cursor, field) =>
       val newCursor = cursor.downField(field).delete
       if(newCursor.succeeded) newCursor.any
       else cursor

--- a/json/circe/src/test/scala/CirceFixture.scala
+++ b/json/circe/src/test/scala/CirceFixture.scala
@@ -1,0 +1,45 @@
+package pdi.jwt
+
+import io.circe._
+import io.circe.syntax._
+import io.circe.jawn.{parse => jawnParse}
+
+case class JsonDataEntry (
+  algo: JwtAlgorithm,
+  header: String,
+  headerClass: JwtHeader,
+  header64: String,
+  signature: String,
+  token: String,
+  tokenUnsigned: String,
+  tokenEmpty: String,
+  headerJson: Json) extends JsonDataEntryTrait[Json]
+
+trait CirceFixture extends JsonCommonFixture[Json] {
+  def parseString(value: String): Json = jawnParse(value).toOption.get
+
+  val claimJson = parseString(claim) match {
+    case j: Json => j
+    case _ => throw new RuntimeException("I want a JObject!")
+  }
+
+  val headerEmptyJson = parseString(headerEmpty) match {
+    case j: Json => j
+    case _ => throw new RuntimeException("I want a JObject!")
+  }
+
+  def mapData(data: DataEntryBase): JsonDataEntry = JsonDataEntry(
+    algo = data.algo,
+    header = data.header,
+    headerClass = data.headerClass,
+    header64 = data.header64,
+    signature = data.signature,
+    token = data.token,
+    tokenUnsigned = data.tokenUnsigned,
+    tokenEmpty = data.tokenEmpty,
+    headerJson = parseString(data.header) match {
+      case j: Json => j
+      case _ => throw new RuntimeException("I want a JObject!")
+    }
+  )
+}

--- a/json/circe/src/test/scala/JwtCirceSpec.scala
+++ b/json/circe/src/test/scala/JwtCirceSpec.scala
@@ -1,0 +1,9 @@
+package pdi.jwt
+
+import io.circe._, io.circe.generic.auto._, io.circe.jawn._, io.circe.syntax._
+import cats.data.Xor
+
+class JwtCirceSpec extends JwtJsonCommonSpec[Json] with CirceFixture {
+  val jwtJsonCommon = JwtCirceJson
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,6 +4,7 @@ object Dependencies {
   object V {
     val play = "2.4.0"
     val json4s = "3.2.10"
+    val circe = "0.2.1"
     val scalatest = "2.2.4"
     val scalatestPlus = "1.4.0-M2"
     val jmockit = "1.17"
@@ -20,6 +21,10 @@ object Dependencies {
     val json4sCore    = "org.json4s" %% "json4s-core"    % V.json4s % "provided"
     val json4sNative  = "org.json4s" %% "json4s-native"  % V.json4s % "provided"
     val json4sJackson = "org.json4s" %% "json4s-jackson" % V.json4s % "provided"
+
+    val circeCore     = "io.circe" %% "circe-core"    % V.circe
+    val circeGeneric  = "io.circe" %% "circe-generic" % V.circe
+    val circeParse    = "io.circe" %% "circe-parse"   % V.circe
 
     val apacheCodec = "commons-codec" % "commons-codec" % V.apacheCodec
     val bouncyCastle = "org.bouncycastle" % "bcpkix-jdk15on" % V.bouncyCastle


### PR DESCRIPTION
Hello, I like your project, but I'm using Circe for json, and I want to avoid multiple json (de)serializers, so I've added support for it in your project. This will also Fix #11 in your issue tracker. A few notes
- I've added a new project called `jwt-circe` and `jwt-circe-legacy` in `json/circe`
- All of the code is in `json/circe/src/main/scala/JwtCirceJson.scala`
- There are tests (all passing on my machine) conforming to your `JwtJsonCommonSpec` in `json/circe/src/test/scala/JwtCirceSpec.scala`
- I've updated the README.md to show that Circe is supported
- I've created a tutorial in `docs/src/main/tut/jwt-circe-jwt-json.md` (wasn't sure what the correct naming convention should be there)

I did bump the version up to 0.4.2 in one of my commits, but moved it back on reconsideration -- thought you should probably do that.

Let me know if you need anything else from me!
