### PR TITLE
update circe to 0.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,8 @@ import Dependencies._
 import com.typesafe.sbt.SbtSite.SiteKeys._
 import com.typesafe.sbt.SbtGhPages.GhPagesKeys._
 
-val previousVersion = "0.5.1"
-val buildVersion = "0.6.0"
+val previousVersion = "0.6.0"
+val buildVersion = "0.6.0fw"
 
 val projects = Seq("coreCommon", "playJson", "json4sNative", "json4sJackson", "circe", "play")
 val crossProjects = projects.map(p => Seq(p + "Legacy", p + "Edge")).flatten

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
   object V {
     val play = "2.5.0"
     val json4s = "3.3.0"
-    val circe = "0.2.1"
+    val circe = "0.3.0"
     val scalatest = "2.2.6"
     val scalatestPlus = "1.4.0"
     val jmockit = "1.17"
@@ -24,7 +24,7 @@ object Dependencies {
 
     val circeCore     = "io.circe" %% "circe-core"    % V.circe
     val circeGeneric  = "io.circe" %% "circe-generic" % V.circe
-    val circeParse    = "io.circe" %% "circe-parse"   % V.circe
+    val circeParse    = "io.circe" %% "circe-parser"  % V.circe
 
     val apacheCodec = "commons-codec" % "commons-codec" % V.apacheCodec
     val bouncyCastle = "org.bouncycastle" % "bcpkix-jdk15on" % V.bouncyCastle


### PR DESCRIPTION
The current version of circe is 0.3.0 which is package name incompatible with 0.2.1. In order to work with finch (in my case) I need an upgraded version of jwt-scala. The code is fully compatible, only the dependency version and the name of one package needed to be changed.
