### PR TITLE
Change audience from Option[String] to Option[Set[String]]

### DIFF
--- a/core/common/src/main/scala/JwtClaim.scala
+++ b/core/common/src/main/scala/JwtClaim.scala
@@ -4,7 +4,7 @@ case class JwtClaim(
   content: String = "{}",
   issuer: Option[String] = None,
   subject: Option[String] = None,
-  audience: Option[String] = None,
+  audience: Option[Set[String]] = None,
   expiration: Option[Long] = None,
   notBefore: Option[Long] = None,
   issuedAt: Option[Long] = None,
@@ -34,7 +34,8 @@ case class JwtClaim(
     this.copy(content = JwtUtils.mergeJson(this.content, JwtUtils.hashToJson(fields)))
 
   def by(issuer: String): JwtClaim = this.copy(issuer = Option(issuer))
-  def to(audience: String): JwtClaim = this.copy(audience = Option(audience))
+  def to(audience: String): JwtClaim = this.copy(audience = Some(Set(audience)))
+  def to(audience: Set[String]): JwtClaim = this.copy(audience = Some(audience))
   def about(subject: String): JwtClaim = this.copy(subject = Option(subject))
   def withId(id: String): JwtClaim = this.copy(jwtId = Option(id))
 
@@ -51,6 +52,6 @@ case class JwtClaim(
   def issuedNow: JwtClaim = this.copy(issuedAt = Option(JwtTime.nowSeconds))
 
   def isValid: Boolean = JwtTime.nowIsBetweenSeconds(this.notBefore, this.expiration)
-  def isValid(issuer: String): Boolean = this.issuer.map(_ == issuer).getOrElse(false) && this.isValid
-  def isValid(issuer: String, audience: String): Boolean = this.audience.map(_ == audience).getOrElse(false) && this.isValid(issuer)
+  def isValid(issuer: String): Boolean = this.issuer.exists(_ == issuer) && this.isValid
+  def isValid(issuer: String, audience: String): Boolean = this.audience.exists(_ contains audience) && this.isValid(issuer)
 }

--- a/core/common/src/main/scala/JwtException.scala
+++ b/core/common/src/main/scala/JwtException.scala
@@ -28,6 +28,10 @@ class JwtNonStringException(key: String) extends RuntimeException(s"During JSON 
   def getKey = key
 }
 
+class JwtNonStringSetOrStringException(key: String) extends RuntimeException(s"During JSON parsing, expected a Set[String] or String for key [$key]") with JwtException {
+  def getKey = key
+}
+
 class JwtNonNumberException(key: String) extends RuntimeException(s"During JSON parsing, expected a Number for key [$key]") with JwtException {
   def getKey = key
 }

--- a/core/common/src/main/scala/JwtUtils.scala
+++ b/core/common/src/main/scala/JwtUtils.scala
@@ -73,6 +73,7 @@ object JwtUtils {
       case (key, value: BigInt) => "\"" + escape(key) + "\":" + value.toString
       case (key, value: (String, Any)) => "\"" + escape(key) + "\":" + hashToJson(Seq(value))
       case (key, value: Seq[Any]) => "\"" + escape(key) + "\":" + seqToJson(value)
+      case (key, value: Set[Any]) => "\"" + escape(key) + "\":" + seqToJson(value.toSeq)
       case (key, value: Any) => "\"" + escape(key) + "\":\"" + escape(value.toString) + "\""
     }.mkString("{", ",", "}")
   }

--- a/json/circe/src/main/scala/JwtCirce.scala
+++ b/json/circe/src/main/scala/JwtCirce.scala
@@ -23,7 +23,7 @@ object JwtCirce extends JwtJsonCommon[Json] {
         content = contentCursor.top.asJson.noSpaces
       , issuer = cursor.get[String]("iss").toOption
       , subject = cursor.get[String]("sub").toOption
-      , audience = cursor.get[String]("aud").toOption
+      , audience = cursor.get[Set[String]]("aud").orElse(cursor.get[String]("aud").map(s => Set(s))).toOption
       , expiration = cursor.get[Long]("exp").toOption
       , notBefore = cursor.get[Long]("nbf").toOption
       , issuedAt = cursor.get[Long]("iat").toOption

--- a/json/json4s-common/src/main/scala/JwtJson4sCommon.scala
+++ b/json/json4s-common/src/main/scala/JwtJson4sCommon.scala
@@ -2,10 +2,11 @@ package pdi.jwt
 
 import org.json4s._
 import org.json4s.JsonDSL.WithBigDecimal._
-
-import pdi.jwt.exceptions.{JwtNonStringException, JwtNonNumberException}
+import pdi.jwt.exceptions.{JwtNonNumberException, JwtNonStringException, JwtNonStringSetOrStringException}
 
 trait JwtJson4sCommon extends JwtJsonCommon[JObject] {
+  protected implicit def formats: Formats
+
   protected def getAlgorithm(header: JObject): Option[JwtAlgorithm] = header \ "alg" match {
     case JString("none") => None
     case JString(algo) => Option(JwtAlgorithm.fromString(algo))
@@ -18,7 +19,7 @@ trait JwtJson4sCommon extends JwtJsonCommon[JObject] {
     case value: JObject => JwtClaim.apply(
       issuer = extractString(value, "iss"),
       subject = extractString(value, "sub"),
-      audience = extractString(value, "aud"),
+      audience = extractStringSetOrString(value, "aud"),
       expiration = extractLong(value, "exp"),
       notBefore = extractLong(value, "nbf"),
       issuedAt = extractLong(value, "iat"),
@@ -46,6 +47,18 @@ trait JwtJson4sCommon extends JwtJsonCommon[JObject] {
     case JNull => None
     case JNothing => None
     case _ => throw new JwtNonStringException(fieldName)
+  }
+
+  private def extractStringSetOrString(json: JObject, fieldName: String): Option[Set[String]] = (json \ fieldName) match {
+    case JString(value) => Option(Set(value))
+    case JArray(_) => try {
+      Some((json \ fieldName).extract[Set[String]])
+    } catch {
+      case MappingException(_, _) => throw new JwtNonStringSetOrStringException(fieldName)
+    }
+    case JNull => None
+    case JNothing => None
+    case _ => throw new JwtNonStringSetOrStringException(fieldName)
   }
 
   private def extractLong(json: JObject, fieldName: String): Option[Long] = (json \ fieldName) match {

--- a/json/json4s-jackson/src/test/scala/Json4sJacksonSpec.scala
+++ b/json/json4s-jackson/src/test/scala/Json4sJacksonSpec.scala
@@ -11,7 +11,7 @@ class JwtJson4sJacksonSpec extends JwtJsonCommonSpec[JObject] with Json4sJackson
     it("should implicitly convert to JValue") {
       assertResult((
         ("iss" -> "me") ~
-        ("aud" -> "you") ~
+        ("aud" -> Set("you")) ~
         ("sub" -> "something") ~
         ("exp" -> 15) ~
         ("nbf" -> 10) ~

--- a/json/json4s-native/src/test/scala/Json4sNativeSpec.scala
+++ b/json/json4s-native/src/test/scala/Json4sNativeSpec.scala
@@ -11,7 +11,7 @@ class JwtJson4sNativeSpec extends JwtJsonCommonSpec[JObject] with Json4sNativeFi
     it("should implicitly convert to JValue") {
       assertResult((
         ("iss" -> "me") ~
-        ("aud" -> "you") ~
+        ("aud" -> Set("you")) ~
         ("sub" -> "something") ~
         ("exp" -> 15) ~
         ("nbf" -> 10) ~

--- a/json/play-json/src/test/scala/JwtJsonSpec.scala
+++ b/json/play-json/src/test/scala/JwtJsonSpec.scala
@@ -9,7 +9,7 @@ class JwtJsonSpec extends JwtJsonCommonSpec[JsObject] with JsonFixture {
     it("should implicitly convert to JsValue") {
       assertResult(Json.obj(
         ("iss" -> "me"),
-        ("aud" -> "you"),
+        ("aud" -> Set("you")),
         ("sub" -> "something"),
         ("exp" -> 15),
         ("nbf" -> 10),


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc7519#section-4.1.3, the "aud" claim is normally an array of strings, but may be a single string.

I am not sure what is the best approach to add regression tests to the project, but the current tests pass (when running `testAll`). Maybe someone could suggest the way to organize the new test code, or just pick it up from here :)
