### PR TITLE
Transformation of Signature to ASN.1 DER for ECDSA Algorithms

### DIFF
--- a/core/common/src/main/scala/JwtException.scala
+++ b/core/common/src/main/scala/JwtException.scala
@@ -8,6 +8,8 @@ class JwtLengthException(message: String) extends RuntimeException(message) with
 
 class JwtValidationException(message: String) extends RuntimeException(message) with JwtException
 
+class JwtSignatureFormatException(message: String) extends RuntimeException(message) with JwtException
+
 class JwtEmptySignatureException() extends RuntimeException("No signature found inside the token while trying to verify it with a key.") with JwtException
 
 class JwtNonEmptySignatureException() extends RuntimeException("Non-empty signature found inside the token while trying to verify without a key.") with JwtException

--- a/core/common/src/test/scala/JwtSpec.scala
+++ b/core/common/src/test/scala/JwtSpec.scala
@@ -117,6 +117,19 @@ class JwtSpec extends UnitSpec with Fixture {
       mock.tearDown
     }
 
+    it("should validate ECDSA from other implementations") {
+      val publicKey = "MIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQASisgweVL1tAtIvfmpoqvdXF8sPKTV9YTKNxBwkdkm+/auh4pR8TbaIfsEzcsGUVv61DFNFXb0ozJfurQ59G2XcgAn3vROlSSnpbIvuhKrzL5jwWDTaYa5tVF1Zjwia/5HUhKBkcPuWGXg05nMjWhZfCuEetzMLoGcHmtvabugFrqsAg="
+      val verifier = (token: String) => {
+        assertResult(true) {
+          Jwt.isValid(token, publicKey, Seq(JwtAlgorithm.ES512))
+        }
+      }
+      //Test verification for token created using https://github.com/auth0/node-jsonwebtoken/tree/v7.0.1
+      verifier("eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJ0ZXN0IjoidGVzdCIsImlhdCI6MTQ2NzA2NTgyN30.Aab4x7HNRzetjgZ88AMGdYV2Ml7kzFbl8Ql2zXvBores7iRqm2nK6810ANpVo5okhHa82MQf2Q_Zn4tFyLDR9z4GAcKFdcAtopxq1h8X58qBWgNOc0Bn40SsgUc8wOX4rFohUCzEtnUREePsvc9EfXjjAH78WD2nq4tn-N94vf14SncQ")
+      //Test verification for token created using https://github.com/jwt/ruby-jwt/tree/v1.5.4
+      verifier("eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzUxMiJ9.eyJ0ZXN0IjoidGVzdCJ9.AV26tERbSEwcoDGshneZmhokg-tAKUk0uQBoHBohveEd51D5f6EIs6cskkgwtfzs4qAGfx2rYxqQXr7LTXCNquKiAJNkTIKVddbPfped3_TQtmHZTmMNiqmWjiFj7Y9eTPMMRRu26w4gD1a8EQcBF-7UGgeH4L_1CwHJWAXGbtu7uMUn")
+    }
+
     it("should invalidate WTF tokens") {
       val tokens = Seq("1", "abcde", "", "a.b.c.d")
 

--- a/core/common/src/test/scala/JwtUtilsSpec.scala
+++ b/core/common/src/test/scala/JwtUtilsSpec.scala
@@ -1,6 +1,9 @@
 package pdi.jwt
 
-import org.scalatest._
+import java.security.{KeyPairGenerator, SecureRandom}
+import java.security.spec.ECGenParameterSpec
+
+import pdi.jwt.exceptions.JwtSignatureFormatException
 
 case class TestObject(value: String) {
   override def toString(): String = this.value
@@ -78,5 +81,70 @@ class JwtUtilsSpec extends UnitSpec {
         }
       }
     }*/
+
+    describe("transcodeSignatureToDER") {
+      it("should throw JwtValidationException if signature is too long") {
+        val signature = JwtUtils.bytify("AU6-jw28DX1QMY0Ar8CTcnIAc0WKGe3nNVHkE7ayHSxvOLxE5YQSiZtbPn3y-vDHoQCOMId4rPdIJhD_NOUqnH_rAKA5w9ZlhtW0GwgpvOg1_5oLWnWXQvPjJjC5YsLqEssoMITtOmfkBsQMgLAF_LElaaCWhkJkOCtcZmroUW_b5CXB")
+        the[JwtSignatureFormatException] thrownBy {
+          JwtUtils.transcodeSignatureToDER(signature ++ signature)
+        } should have message "Invalid ECDSA signature format"
+      }
+
+      it("should transocde empty signature") {
+        val signature: Array[Byte] = Array[Byte](0)
+        JwtUtils.transcodeSignatureToDER(signature)
+      }
+    }
+
+    describe("transcodeSignatureToConcat") {
+      it("should throw JwtValidationException if length incorrect") {
+        val signature = JwtUtils.bytify("MIEAAGg3OVb/ZeX12cYrhK3c07TsMKo7Kc6SiqW++4CAZWCX72DkZPGTdCv2duqlupsnZL53hiG3rfdOLj8drndCU+KHGrn5EotCATdMSLCXJSMMJoHMM/ZPG+QOHHPlOWnAvpC1v4lJb32WxMFNz1VAIWrl9Aa6RPG1GcjCTScKjvEE")
+        the[JwtSignatureFormatException] thrownBy {
+          JwtUtils.transcodeSignatureToConcat(signature, 132)
+        } should have message "Invalid ECDSA signature format"
+      }
+
+      it("should throw JwtValidationException if signature is incorrect ") {
+        val signature = JwtUtils.bytify("MIGBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+        the[JwtSignatureFormatException] thrownBy {
+          JwtUtils.transcodeSignatureToConcat(signature, 132)
+        } should have message "Invalid ECDSA signature format"
+      }
+
+      it("should throw JwtValidationException if signature is incorrect 2") {
+        val signature = JwtUtils.bytify("MIGBAD4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+        the[JwtSignatureFormatException] thrownBy {
+          JwtUtils.transcodeSignatureToConcat(signature, 132)
+        } should have message "Invalid ECDSA signature format"
+      }
+    }
+
+    describe("transcodeSignatureToConcat and transcodeSignatureToDER") {
+      it("should be symmetric") {
+        val signature = JwtUtils.bytify("AbxLPbA3dm9V0jt6c_ahf8PYioFvnryTe3odgolhcgwBUl4ifpwUBJ--GgiXC8vms45c8vI40ZSdkm5NoNn1wTHOAfkepNy-RRKHmBzAoWrWmBIb76yPa0lsjdAPEAXcbGfaQV8pKq7W10dpB2B-KeJxVonMuCLJHPuqsUl9S7CfASu2")
+        val dER: Array[Byte] = JwtUtils.transcodeSignatureToDER(signature)
+        val result = JwtUtils.transcodeSignatureToConcat(dER, JwtUtils.getSignatureByteArrayLength(JwtAlgorithm.ES512))
+        assertResult(signature) {
+          result
+        }
+      }
+
+      it("should be symmetric for generated tokens") {
+        val ecGenSpec = new ECGenParameterSpec("P-521")
+        val generatorEC = KeyPairGenerator.getInstance(JwtUtils.ECDSA, JwtUtils.PROVIDER)
+        generatorEC.initialize(ecGenSpec, new SecureRandom())
+        val randomECKey = generatorEC.generateKeyPair()
+        val header = """{"typ":"JWT","alg":"ES512"}"""
+        val claim = """{"test":"t"}"""
+
+        val signature = Jwt.encode(header, claim, randomECKey.getPrivate, JwtAlgorithm.ES512).split("\\.")(2)
+        assertResult(signature) {
+          JwtUtils.stringify(JwtUtils.transcodeSignatureToConcat(JwtUtils.transcodeSignatureToDER(JwtUtils.bytify(signature)),
+            JwtUtils.getSignatureByteArrayLength(JwtAlgorithm.ES512)))
+        }
+      }
+    }
+
+
   }
 }


### PR DESCRIPTION
add transformation to ASN.1 DER to support other implementations. See https://github.com/jwtk/jjwt/pull/137 for the corresponding implementation in java.
