### PR TITLE
Fix the tut runtime issue in the upickle docs

### DIFF
--- a/json/upickle/src/main/scala/JwtUpickle.scala
+++ b/json/upickle/src/main/scala/JwtUpickle.scala
@@ -9,7 +9,7 @@ import upickle.default._
   *
   * To see a full list of samples, check the [[http://pauldijou.fr/jwt-scala/samples/jwt-upickle/ online documentation]].
   */
-object JwtUpickle extends JwtJsonCommon[Js.Value] {
+object JwtUpickle extends JwtJsonCommon[Js.Value] with JwtUpickleImplicits {
   protected def parse(value: String): Js.Value = json.read(value)
 
   protected def stringify(value: Js.Value): String = json.write(value)

--- a/json/upickle/src/main/scala/package.scala
+++ b/json/upickle/src/main/scala/package.scala
@@ -1,3 +1,0 @@
-package pdi
-
-package object jwt extends JwtUpickleImplicits {}


### PR DESCRIPTION
As mentioned in #39 regarding the runtime error when generating the upickle docs, this PR fixes the issue.

This also reverts the code back to my first PR in where the upickle implicits trait is mixed in with the `JwtUpickle` object instead of the package object, feel free to reject it or propose a different encoding.

Worth mentioning that if this encoding is accepted, is probably better to make the `JwtUpickleImplicits` trait package private to prevent users extending it.