### PR TITLE
Remove all package.scala

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.12.0 (20/02/2017)
+
+- **Breaking changes** I liked having all implicits directly inside the package object but it started to create problems. When generating the documentation, which depends on all projects, we had runtime errors while all tests were green, but they are ran on project at a time. Also, it means all implicits where always present on the scope which might not be the best option. So the idea is to move them from the package object to the `JwtXXX` object. For example, for Play Json:
+
+```scala
+// Before
+// JwtJson.scala.
+package pdi.jwt
+
+object JwtJson extends JwtJsonCommon[JsObject] {
+  // stuff...
+}
+
+// package.scala
+package pdi
+
+package object jwt extends JwtJsonImplicits {}
+
+// --------------------------------------------------------
+// After
+// JwtJson.scala.
+package pdi.jwt
+
+object JwtJson extends JwtJsonCommon[JsObject] with JwtJsonImplicits {
+  // stuff...
+}
+```
+
 ## 0.11.0 (19/02/2017)
 
 - Drop Scala 2.10

--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,8 @@ import play.sbt.Play.autoImport._
 import PlayKeys._
 import Dependencies._
 
-val previousVersion = "0.10.0"
-val buildVersion = "0.11.0"
+val previousVersion = "0.11.0"
+val buildVersion = "0.12.0"
 
 val projects = Seq("coreCommon", "playJson", "json4sNative", "json4sJackson", "circe", "upickle", "play")
 val crossProjects = projects.map(p => Seq(p + "Legacy", p + "Edge")).flatten

--- a/docs/src/main/tut/_includes/tut/jwt-play-json-jwt-json.md
+++ b/docs/src/main/tut/_includes/tut/jwt-play-json-jwt-json.md
@@ -46,6 +46,7 @@ The project provides implicit reader and writer for both `JwtHeader` and `JwtCla
 
 ```tut
 import pdi.jwt._
+import pdi.jwt.JwtJson._
 
 // Reads
 Json.fromJson[JwtHeader](header)

--- a/docs/src/main/tut/_includes/tut/jwt-play-jwt-session.md
+++ b/docs/src/main/tut/_includes/tut/jwt-play-jwt-session.md
@@ -65,7 +65,9 @@ session2.getAs[User]("user")
 You can extract a `JwtSession` from a `RequestHeader`.
 
 ```tut
-import pdi.jwt._, play.api.test.{FakeRequest, FakeHeaders}
+import pdi.jwt._
+import pdi.jwt.JwtSession._
+import play.api.test.{FakeRequest, FakeHeaders}
 
 // Default JwtSession
 FakeRequest().jwtSession

--- a/docs/src/main/tut/_includes/tut/jwt-upickle-jwt-upickle.md
+++ b/docs/src/main/tut/_includes/tut/jwt-upickle-jwt-upickle.md
@@ -1,10 +1,8 @@
 ## JwtUpickle Object
 
-**Compilation problem** Right now, even if all tests are green, there is a problem for compiling this documentation file.
-
 ### Basic usage
 
-```
+```tut
 import java.time.Instant
 import upickle.json
 import upickle.default._
@@ -25,7 +23,7 @@ JwtUpickle.decode(token, key, Seq(JwtAlgorithm.HS256))
 
 ### Encoding
 
-```
+```tut
 val key = "secretKey"
 val algo = JwtAlgorithm.HS256
 
@@ -39,7 +37,7 @@ JwtUpickle.encode(header, claimJson, key)
 
 ### Decoding
 
-```
+```tut
 val claim = JwtClaim(
   expiration = Some(Instant.now.plusSeconds(157784760).getEpochSecond),
   issuedAt = Some(Instant.now.getEpochSecond)

--- a/json/json4s-jackson/src/main/scala/JwtJson4sJackson.scala
+++ b/json/json4s-jackson/src/main/scala/JwtJson4sJackson.scala
@@ -12,7 +12,7 @@ import org.json4s.jackson.Serialization.{read, write}
   *
   * To see a full list of samples, check the [[http://pauldijou.fr/jwt-scala/samples/jwt-json4s/ online documentation]].
   */
-object JwtJson4s extends JwtJson4sCommon {
+object JwtJson4s extends JwtJson4sCommon with JwtJson4sImplicits {
   protected def parse(value: String): JObject = jparse(value) match {
     case res: JObject => res
     case _ => throw new RuntimeException(s"Couldn't parse [$value] to a JObject")

--- a/json/json4s-jackson/src/main/scala/package.scala
+++ b/json/json4s-jackson/src/main/scala/package.scala
@@ -1,3 +1,0 @@
-package pdi
-
-package object jwt extends JwtJson4sImplicits {}

--- a/json/json4s-jackson/src/test/scala/Json4sJacksonSpec.scala
+++ b/json/json4s-jackson/src/test/scala/Json4sJacksonSpec.scala
@@ -5,6 +5,8 @@ import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods._
 
 class JwtJson4sJacksonSpec extends JwtJsonCommonSpec[JObject] with Json4sJacksonFixture {
+  import pdi.jwt.JwtJson4s._
+
   val jwtJsonCommon = JwtJson4s
 
   describe("JwtJson") {

--- a/json/json4s-native/src/main/scala/JwtJson4sNative.scala
+++ b/json/json4s-native/src/main/scala/JwtJson4sNative.scala
@@ -12,7 +12,7 @@ import org.json4s.native.Serialization.{read, write}
   *
   * To see a full list of samples, check the [[http://pauldijou.fr/jwt-scala/samples/jwt-json4s/ online documentation]].
   */
-object JwtJson4s extends JwtJson4sCommon {
+object JwtJson4s extends JwtJson4sCommon with JwtJson4sImplicits {
   protected def parse(value: String): JObject = jparse(value) match {
     case res: JObject => res
     case _ => throw new RuntimeException(s"Couldn't parse [$value] to a JObject")

--- a/json/json4s-native/src/main/scala/package.scala
+++ b/json/json4s-native/src/main/scala/package.scala
@@ -1,3 +1,0 @@
-package pdi
-
-package object jwt extends JwtJson4sImplicits {}

--- a/json/json4s-native/src/test/scala/Json4sNativeSpec.scala
+++ b/json/json4s-native/src/test/scala/Json4sNativeSpec.scala
@@ -5,6 +5,8 @@ import org.json4s.JsonDSL._
 import org.json4s.native.JsonMethods._
 
 class JwtJson4sNativeSpec extends JwtJsonCommonSpec[JObject] with Json4sNativeFixture {
+  import pdi.jwt.JwtJson4s._
+
   val jwtJsonCommon = JwtJson4s
 
   describe("JwtJson") {

--- a/json/play-json/src/main/scala/JwtJson.scala
+++ b/json/play-json/src/main/scala/JwtJson.scala
@@ -9,7 +9,7 @@ import pdi.jwt.exceptions.JwtNonStringException
   *
   * To see a full list of samples, check the [[http://pauldijou.fr/jwt-scala/samples/jwt-play-json/ online documentation]].
   */
-object JwtJson extends JwtJsonCommon[JsObject] {
+object JwtJson extends JwtJsonCommon[JsObject] with JwtJsonImplicits {
   protected def parse(value: String): JsObject = Json.parse(value).as[JsObject]
 
   protected def stringify(value: JsObject): String = Json.stringify(value)

--- a/json/play-json/src/main/scala/package.scala
+++ b/json/play-json/src/main/scala/package.scala
@@ -1,3 +1,0 @@
-package pdi
-
-package object jwt extends JwtJsonImplicits {}

--- a/json/play-json/src/test/scala/JsonFixture.scala
+++ b/json/play-json/src/test/scala/JsonFixture.scala
@@ -14,6 +14,8 @@ case class JsonDataEntry (
   headerJson: JsObject) extends JsonDataEntryTrait[JsObject]
 
 trait JsonFixture extends JsonCommonFixture[JsObject] {
+  import pdi.jwt.JwtJson._
+  
   val claimJson = jwtPlayJsonClaimWriter.writes(claimClass).as[JsObject]
   val headerEmptyJson = jwtPlayJsonHeaderWriter.writes(headerClassEmpty).as[JsObject]
 

--- a/json/play-json/src/test/scala/JwtJsonSpec.scala
+++ b/json/play-json/src/test/scala/JwtJsonSpec.scala
@@ -3,6 +3,8 @@ package pdi.jwt
 import play.api.libs.json.{Json, JsObject}
 
 class JwtJsonSpec extends JwtJsonCommonSpec[JsObject] with JsonFixture {
+  import pdi.jwt.JwtJson._
+  
   val jwtJsonCommon = JwtJson
 
   describe("JwtJson") {

--- a/play/src/main/scala/package.scala
+++ b/play/src/main/scala/package.scala
@@ -1,3 +1,0 @@
-package pdi
-
-package object jwt extends JwtJsonImplicits with JwtPlayImplicits {}

--- a/play/src/test/scala/JwtResultSpec.scala
+++ b/play/src/test/scala/JwtResultSpec.scala
@@ -13,6 +13,8 @@ import play.api.mvc.Results._
 import play.api.libs.json._
 
 class JwtResultSpec extends PlaySpec with GuiceOneAppPerSuite with PlayFixture {
+  import pdi.jwt.JwtSession._
+
   val HEADER_NAME = "Authorization"
   val materializer: Materializer = app.materializer
 

--- a/play/src/test/scala/JwtSessionCustomSpec.scala
+++ b/play/src/test/scala/JwtSessionCustomSpec.scala
@@ -13,6 +13,8 @@ import play.api.mvc.Results._
 import play.api.libs.json._
 
 class JwtSessionCustomSpec extends PlaySpec with GuiceOneAppPerSuite with BeforeAndAfter with PlayFixture {
+  import pdi.jwt.JwtSession._
+  
   val materializer: Materializer = app.materializer
 
   // Just for test, users shouldn't change the header name normally

--- a/play/src/test/scala/JwtSessionSpec.scala
+++ b/play/src/test/scala/JwtSessionSpec.scala
@@ -13,6 +13,8 @@ import play.api.mvc.Results._
 import play.api.libs.json._
 
 class JwtSessionSpec extends PlaySpec with GuiceOneAppPerSuite with PlayFixture {
+  import pdi.jwt.JwtSession._
+  
   val materializer: Materializer = app.materializer
 
   def HEADER_NAME = "Authorization"

--- a/play/src/test/scala/PlayFixture.scala
+++ b/play/src/test/scala/PlayFixture.scala
@@ -14,6 +14,8 @@ import play.api.libs.json._
 case class User(id: Long, name: String)
 
 trait PlayFixture extends Fixture {
+  import pdi.jwt.JwtSession._
+  
   def HEADER_NAME: String
   def materializer: Materializer
 


### PR DESCRIPTION
**Breaking changes** I liked having all implicits directly inside the package object but it started to create problems.

When generating the documentation, which depends on all projects, we had runtime errors while all tests were green, but they are ran on one project at a time. Also, it means all implicits where always present on the scope which might not be the best option. I had a lot of feedback about IDE lost when working with `jwt-scala`.

So the idea is to move them from the package object to the `JwtXXX` object. For example, for Play Json:

```scala
// Before
// JwtJson.scala.
package pdi.jwt

object JwtJson extends JwtJsonCommon[JsObject] {
  // stuff...
}

// package.scala
package pdi

package object jwt extends JwtJsonImplicits {}

// --------------------------------------------------------
// After
// JwtJson.scala.
package pdi.jwt

object JwtJson extends JwtJsonCommon[JsObject] with JwtJsonImplicits {
  // stuff...
}
```

For your code, it means that importing `pdi.jwt._` will no longer be enough. You will need to import the matching `JwtXXX` object. For example, for Play Json, it will be `pdi.jwt.JwtJson._`.

I will wait a bit to have feedback from users before merging and releasing.