### PR TITLE
upgrade Bouncy Castle to 1.57

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
     val scalatestPlus = "2.0.0-M2"
     val jmockit = "1.24"
     val apacheCodec = "1.10"
-    val bouncyCastle = "1.52"
+    val bouncyCastle = "1.57"
     val upickle = "0.4.4"
     val guice = "4.1.0"
   }


### PR DESCRIPTION
Bouncy Castle 1.52 is years out of date and includes security vulnerabilities that have been resolved, so I'd like to see how difficult it is to include a more recent version.  I'm not a Scala or Java native and my sbt-fu is weak, so I was unable to run tests, but I did verify `sbt compile` worked and included Bouncy Castle version 1.57.

I see from other issues that you may not have time or desire to update this dependency.  If that is the case please let me know and close this issue on Github.

Thanks for all of your hard work on this library.