### PR TITLE
Update “hack” to catch Duration.Inf.toMillils now throwing IllegalArgumentException.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,8 @@ import play.sbt.Play.autoImport._
 import PlayKeys._
 import Dependencies._
 
-val previousVersion = "0.13.0"
-val buildVersion = "0.14.0"
+val previousVersion = "0.14.0"
+val buildVersion = "0.14.1"
 
 val projects = Seq("coreCommon", "playJson", "json4sNative", "json4sJackson", "circe", "upickle", "play")
 val crossProjects = projects.map(p => Seq(p + "Legacy", p + "Edge")).flatten

--- a/play/src/main/scala/JwtSession.scala
+++ b/play/src/main/scala/JwtSession.scala
@@ -86,10 +86,10 @@ object JwtSession extends JwtJsonImplicits with JwtPlayImplicits {
     getter(key)
   } catch {
     case e: com.typesafe.config.ConfigException.Null => None
+    case _: IllegalArgumentException => None
     case e: java.lang.RuntimeException => {
       e.getCause() match {
         case _: com.typesafe.config.ConfigException.Null => None
-        case _: IllegalArgumentException => None
         case _ => throw e
       }
     }

--- a/play/src/main/scala/JwtSession.scala
+++ b/play/src/main/scala/JwtSession.scala
@@ -89,6 +89,7 @@ object JwtSession extends JwtJsonImplicits with JwtPlayImplicits {
     case e: java.lang.RuntimeException => {
       e.getCause() match {
         case _: com.typesafe.config.ConfigException.Null => None
+        case _: IllegalArgumentException => None
         case _ => throw e
       }
     }

--- a/play/src/main/scala/JwtSession.scala
+++ b/play/src/main/scala/JwtSession.scala
@@ -5,6 +5,8 @@ import play.api.libs.json._
 import play.api.libs.json.Json.JsValueWrapper
 import pdi.jwt.algorithms.JwtHmacAlgorithm
 
+import scala.concurrent.duration.FiniteDuration
+
 /** Similar to the default Play Session but using JsObject instead of Map[String, String]. The data is separated into two attributes:
   * `headerData` and `claimData`. There is also a optional signature. Most of the time, you should only care about the `claimData` which
   * stores the claim of the token containing the custom values you eventually put in it. That's why all methods of `JwtSession` (such as
@@ -86,7 +88,6 @@ object JwtSession extends JwtJsonImplicits with JwtPlayImplicits {
     getter(key)
   } catch {
     case e: com.typesafe.config.ConfigException.Null => None
-    case _: IllegalArgumentException => None
     case e: java.lang.RuntimeException => {
       e.getCause() match {
         case _: com.typesafe.config.ConfigException.Null => None
@@ -100,7 +101,7 @@ object JwtSession extends JwtJsonImplicits with JwtPlayImplicits {
   )
 
   val getConfigMillis = wrap[Long](
-    key => Play.maybeApplication.flatMap(_.configuration.getMilliseconds(key))
+    key => Play.maybeApplication.flatMap(_.configuration.getOptional[FiniteDuration](key).map(_.toMillis))
   )
 
   val REQUEST_HEADER_NAME: String = getConfigString("play.http.session.jwtName").getOrElse("Authorization")


### PR DESCRIPTION
Using any version of Play 2.6.X the default value of play.http.session.maxAge of null is being converted to Duration.Inf. https://github.com/playframework/playframework/commit/84c883d3865266da10706eddd71026821912000c#diff-4378e6503263d81d7869f6056b31e6b1L1037

```
private[this] def fail(what: String) = throw new IllegalArgumentException(s"$what not allowed on infinite Durations")
    final def length: Long    = fail("length")
    final def unit: TimeUnit  = fail("unit")
    final def toNanos: Long   = fail("toNanos")
    final def toMicros: Long  = fail("toMicros")
    final def toMillis: Long  = fail("toMillis")
    final def toSeconds: Long = fail("toSeconds")
    final def toMinutes: Long = fail("toMinutes")
    final def toHours: Long   = fail("toHours")
    final def toDays: Long    = fail("toDays")
```

IllegalArgumentException is now being thrown where ConfigException.Null may have been thrown in the past.

Another route to go instead of using this hack could be to use getOptional[Long] instead of getMilliseconds since it uses getOptional[Duration].map(_.toMillis). This would prevent the use of a Duration in the maxAge field when using this library, but may be less brittle going forward.

I apologize if this PR isn't fully complete. This is my first open source PR, and can definitely make changes to documentation that I may have missed, or make changes to version numbers and resubmit.