### PR TITLE
Bump circe to 0.9.0. Bump project version number

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,8 @@ import play.sbt.Play.autoImport._
 import PlayKeys._
 import Dependencies._
 
-val previousVersion = "0.14.0"
-val buildVersion = "0.14.1"
+val previousVersion = "0.14.1"
+val buildVersion = "0.14.2"
 
 val projects = Seq("coreCommon", "playJson", "json4sNative", "json4sJackson", "circe", "upickle", "play")
 val crossProjects = projects.map(p => Seq(p + "Legacy", p + "Edge")).flatten

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
   object V {
     val play = "2.6.6"
     val json4s = "3.5.3"
-    val circe = "0.8.0"
+    val circe = "0.9.0"
     val scalatest = "3.2.0-SNAP4"
     val scalatestPlus = "3.0.0-RC1"
     val jmockit = "1.24"


### PR DESCRIPTION
Hi @pauldijou !
Could you please, release a new version with circe 0.9.0? 

I bumped project version to 0.14.2 within this PR, but I can revert that if you prefer to do it yourself :)

Tests were green for me locally in `circeEdge` and `circeLegacy`