### PR TITLE
Update to circe 0.9.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
   object V {
     val play = "2.6.6"
     val json4s = "3.5.3"
-    val circe = "0.8.0"
+    val circe = "0.9.0"
     val scalatest = "3.2.0-SNAP4"
     val scalatestPlus = "3.0.0-RC1"
     val jmockit = "1.24"


### PR DESCRIPTION
This updates to the latest circe release. The test suite has one failing test but this one also fails on `master`.

Could someone please have a closer look to verify if I need to put more work into this?

### Changes

* update circe dependency to 0.9.0
