### PR TITLE
Make JwtCirce.parseHeader public

### DIFF
--- a/json/circe/src/main/scala/JwtCirce.scala
+++ b/json/circe/src/main/scala/JwtCirce.scala
@@ -27,7 +27,7 @@ trait JwtCirceParser[H, C] extends JwtJsonCommon[Json, H, C] {
 }
 
 object JwtCirce extends JwtCirceParser[JwtHeader, JwtClaim] {
-  protected def parseHeader(header: String): JwtHeader = {
+  def parseHeader(header: String): JwtHeader = {
     val cursor = parse(header).hcursor
     JwtHeader(
         algorithm = getAlg(cursor)


### PR DESCRIPTION
It's sometimes necessary to parse the header prior to validating tokens.