### PR TITLE
Bump bouncyCastle to 1.60 to fix CVE-2018-1000613

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
     val scalatestPlus = "3.1.2"
     val jmockit = "1.24"
     val apacheCodec = "1.10"
-    val bouncyCastle = "1.57"
+    val bouncyCastle = "1.60"
     val upickle = "0.6.6"
     val sprayJson = "1.3.4"
     val guice = "4.2.0"


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1000613