### PR TITLE
added play 2.7 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,8 @@ import Dependencies._
 import scala.sys.process._
 import com.typesafe.sbt.pgp.PgpKeys._
 
-val previousVersion = "1.0.0"
-val buildVersion = "1.1.0"
+val previousVersion = "1.1.0"
+val buildVersion = "1.1.1"
 
 val projects = Seq("coreCommon", "playJson", "json4sNative", "json4sJackson", "sprayJson", "circe", "upickle", "argonaut", "play")
 val crossProjects = projects.map(p => Seq(p + "Legacy", p + "Edge")).flatten

--- a/play/src/main/scala/JwtPlayImplicits.scala
+++ b/play/src/main/scala/JwtPlayImplicits.scala
@@ -1,19 +1,20 @@
 package pdi.jwt
 
-import play.api.Play
-import play.api.mvc.{Result, RequestHeader}
-import play.api.libs.json.{Json, JsObject, JsString, Writes}
+import javax.inject.Inject
+import play.api.{Configuration, Play}
+import play.api.mvc.{RequestHeader, Result}
+import play.api.libs.json.{JsObject, JsString, Json, Writes}
 import play.api.libs.json.Json.JsValueWrapper
 
 trait JwtPlayImplicits {
-  private def sanitizeHeader(header: String): String =
+  private def sanitizeHeader(header: String)(implicit conf:Configuration): String =
     if (header.startsWith(JwtSession.TOKEN_PREFIX)) {
       header.substring(JwtSession.TOKEN_PREFIX.length()).trim
     } else {
       header.trim
     }
 
-  private def requestToJwtSession(request: RequestHeader): JwtSession =
+  private def requestToJwtSession(request: RequestHeader)(implicit conf:Configuration): JwtSession =
     request.headers.get(JwtSession.REQUEST_HEADER_NAME).map(sanitizeHeader).map(JwtSession.deserialize).getOrElse(JwtSession())
 
   /** By adding `import pdi.jwt._`, you will implicitely add all those methods to `Result` allowing you to easily manipulate
@@ -37,7 +38,7 @@ trait JwtPlayImplicits {
     * }
     * }}}
     */
-  implicit class RichResult(result: Result) {
+  implicit class RichResult @Inject()(result: Result)(implicit conf:Configuration) {
     /** Retrieve the current [[JwtSession]] from the headers (first from the Result then from the RequestHeader), if none, create a new one.
       * @return the JwtSession inside the headers or a new one
       */
@@ -105,7 +106,7 @@ trait JwtPlayImplicits {
     * }
     * }}}
     */
-  implicit class RichRequestHeader(request: RequestHeader) {
+  implicit class RichRequestHeader @Inject()(request: RequestHeader)(implicit conf:Configuration) {
     /** Return the current [[JwtSession]] from the request */
     def jwtSession: JwtSession = requestToJwtSession(request)
   }

--- a/play/src/test/scala/JwrSessionCustomDifferentNameSpec.scala
+++ b/play/src/test/scala/JwrSessionCustomDifferentNameSpec.scala
@@ -7,15 +7,17 @@ import org.scalatestplus.play._
 import org.scalatestplus.play.guice._
 import play.api.inject.guice.GuiceApplicationBuilder
 import akka.stream.Materializer
-
+import play.api.Configuration
 import play.api.mvc._
 import play.api.mvc.Results._
 import play.api.libs.json._
 
-class JwrSessionCustomDifferentNameSpec extends PlaySpec with GuiceOneAppPerSuite with BeforeAndAfter with PlayFixture {
+class JwrSessionCustomDifferentNameSpec extends PlaySpec with GuiceOneAppPerSuite with BeforeAndAfter with Injecting with PlayFixture {
   import pdi.jwt.JwtSession._
 
-  val materializer: Materializer = app.materializer
+  implicit lazy val conf:Configuration = app.configuration
+  implicit lazy val materializer: Materializer = app.materializer
+  implicit lazy val Action:DefaultActionBuilder = app.injector.instanceOf(classOf[DefaultActionBuilder])
 
   // Just for test, users shouldn't change the header name normally
   def HEADER_NAME = "Auth"
@@ -44,18 +46,19 @@ class JwrSessionCustomDifferentNameSpec extends PlaySpec with GuiceOneAppPerSuit
       ))
       .build()
 
+
   def session = JwtSession()
   def sessionCustom = JwtSession(JwtHeader(JwtAlgorithm.HS512), claimClass, "ngZsdQj8p2wvUAo8xCbJPwganGPnG5UnLkg7VrE6NgmQdV16UITjlBajZxcai_U5PjQdeN-yJtyA5kxf8O5BOQ")
   def tokenCustom = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9." + claim64 + ".ngZsdQj8p2wvUAo8xCbJPwganGPnG5UnLkg7VrE6NgmQdV16UITjlBajZxcai_U5PjQdeN-yJtyA5kxf8O5BOQ"
 
   "Init FakeApplication" must {
     "have the correct config" in {
-      app.configuration.getString("play.http.secret.key") mustEqual Option(secretKey)
-      app.configuration.getString("play.http.session.jwtName") mustEqual Option(HEADER_NAME)
-      app.configuration.getString("play.http.session.jwtResponseName") mustEqual Option(RESPONSE_HEADER_NAME)
-      app.configuration.getString("play.http.session.algorithm") mustEqual Option("HS512")
-      app.configuration.getString("play.http.session.tokenPrefix") mustEqual Option("")
-      app.configuration.getMilliseconds("play.http.session.maxAge") mustEqual Option(sessionTimeout * 1000)
+      app.configuration.getOptional[String]("play.http.secret.key") mustEqual Option(secretKey)
+      app.configuration.getOptional[String]("play.http.session.jwtName") mustEqual Option(HEADER_NAME)
+      app.configuration.getOptional[String]("play.http.session.jwtResponseName") mustEqual Option(RESPONSE_HEADER_NAME)
+      app.configuration.getOptional[String]("play.http.session.algorithm") mustEqual Option("HS512")
+      app.configuration.getOptional[String]("play.http.session.tokenPrefix") mustEqual Option("")
+      app.configuration.getOptional[Int]("play.http.session.maxAge") mustEqual Option(sessionTimeout * 1000)
     }
   }
 

--- a/play/src/test/scala/JwtResultSpec.scala
+++ b/play/src/test/scala/JwtResultSpec.scala
@@ -7,21 +7,25 @@ import org.scalatestplus.play._
 import org.scalatestplus.play.guice._
 import play.api.inject.guice.GuiceApplicationBuilder
 import akka.stream.Materializer
-
+import play.api.Configuration
 import play.api.mvc._
 import play.api.mvc.Results._
 import play.api.libs.json._
 
-class JwtResultSpec extends PlaySpec with GuiceOneAppPerSuite with PlayFixture {
+class JwtResultSpec extends PlaySpec with GuiceOneAppPerSuite with Injecting with PlayFixture {
   import pdi.jwt.JwtSession._
 
+  implicit lazy val conf:Configuration = app.configuration
+  implicit lazy val materializer: Materializer = app.materializer
+  implicit lazy val Action:DefaultActionBuilder = app.injector.instanceOf(classOf[DefaultActionBuilder])
+
   val HEADER_NAME = "Authorization"
-  val materializer: Materializer = app.materializer
 
   override def fakeApplication() =
     new GuiceApplicationBuilder()
       .configure(Map("play.http.secret.key" -> secretKey))
       .build()
+
 
   val session = JwtSession().withHeader(JwtHeader(JwtAlgorithm.HS256))
 

--- a/play/src/test/scala/JwtSessionCustomSpec.scala
+++ b/play/src/test/scala/JwtSessionCustomSpec.scala
@@ -7,7 +7,7 @@ import org.scalatestplus.play._
 import org.scalatestplus.play.guice._
 import play.api.inject.guice.GuiceApplicationBuilder
 import akka.stream.Materializer
-
+import play.api.Configuration
 import play.api.mvc._
 import play.api.mvc.Results._
 import play.api.libs.json._
@@ -15,7 +15,9 @@ import play.api.libs.json._
 class JwtSessionCustomSpec extends PlaySpec with GuiceOneAppPerSuite with BeforeAndAfter with PlayFixture {
   import pdi.jwt.JwtSession._
 
-  val materializer: Materializer = app.materializer
+  implicit lazy val conf:Configuration = app.configuration
+  implicit lazy val materializer: Materializer = app.materializer
+  implicit lazy val Action:DefaultActionBuilder = app.injector.instanceOf(classOf[DefaultActionBuilder])
 
   // Just for test, users shouldn't change the header name normally
   def HEADER_NAME = "Auth"
@@ -42,17 +44,18 @@ class JwtSessionCustomSpec extends PlaySpec with GuiceOneAppPerSuite with Before
       ))
       .build()
 
+
   def session = JwtSession()
   def sessionCustom = JwtSession(JwtHeader(JwtAlgorithm.HS512), claimClass, "ngZsdQj8p2wvUAo8xCbJPwganGPnG5UnLkg7VrE6NgmQdV16UITjlBajZxcai_U5PjQdeN-yJtyA5kxf8O5BOQ")
   def tokenCustom = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9." + claim64 + ".ngZsdQj8p2wvUAo8xCbJPwganGPnG5UnLkg7VrE6NgmQdV16UITjlBajZxcai_U5PjQdeN-yJtyA5kxf8O5BOQ"
 
   "Init FakeApplication" must {
     "have the correct config" in {
-      app.configuration.getString("play.http.secret.key") mustEqual Option(secretKey)
-      app.configuration.getString("play.http.session.jwtName") mustEqual Option(HEADER_NAME)
-      app.configuration.getString("play.http.session.algorithm") mustEqual Option("HS512")
-      app.configuration.getString("play.http.session.tokenPrefix") mustEqual Option("")
-      app.configuration.getMilliseconds("play.http.session.maxAge") mustEqual Option(sessionTimeout * 1000)
+      app.configuration.getOptional[String]("play.http.secret.key") mustEqual Option(secretKey)
+      app.configuration.getOptional[String]("play.http.session.jwtName") mustEqual Option(HEADER_NAME)
+      app.configuration.getOptional[String]("play.http.session.algorithm") mustEqual Option("HS512")
+      app.configuration.getOptional[String]("play.http.session.tokenPrefix") mustEqual Option("")
+      app.configuration.getOptional[Int]("play.http.session.maxAge") mustEqual Option(sessionTimeout * 1000)
     }
   }
 

--- a/play/src/test/scala/JwtSessionSpec.scala
+++ b/play/src/test/scala/JwtSessionSpec.scala
@@ -7,7 +7,7 @@ import org.scalatestplus.play._
 import org.scalatestplus.play.guice._
 import play.api.inject.guice.GuiceApplicationBuilder
 import akka.stream.Materializer
-
+import play.api.Configuration
 import play.api.mvc._
 import play.api.mvc.Results._
 import play.api.libs.json._
@@ -15,7 +15,10 @@ import play.api.libs.json._
 class JwtSessionSpec extends PlaySpec with GuiceOneAppPerSuite with PlayFixture {
   import pdi.jwt.JwtSession._
 
-  val materializer: Materializer = app.materializer
+  implicit lazy val conf:Configuration = app.configuration
+  implicit lazy val materializer: Materializer = app.materializer
+  implicit lazy val Action: DefaultActionBuilder = app.injector.instanceOf(classOf[DefaultActionBuilder])
+
 
   def HEADER_NAME = "Authorization"
 
@@ -27,6 +30,7 @@ class JwtSessionSpec extends PlaySpec with GuiceOneAppPerSuite with PlayFixture 
       ))
       .build()
 
+
   val session = JwtSession().withHeader(JwtHeader(JwtAlgorithm.HS256))
   val session2 = session ++ (("a", 1), ("b", "c"), ("e", true), ("f", Seq(1, 2, 3)), ("user", user))
   val session3 = JwtSession(JwtHeader(JwtAlgorithm.HS256), claimClass, "IPSERPZc5wyxrZ4Yiq7l31wFk_qaDY5YrnfLjIC0Lmc")
@@ -35,7 +39,7 @@ class JwtSessionSpec extends PlaySpec with GuiceOneAppPerSuite with PlayFixture 
 
   "Init FakeApplication" must {
     "have the correct config" in {
-      app.configuration.getString("play.http.secret.key") mustEqual Option(secretKey)
+      app.configuration.getOptional[String]("play.http.secret.key") mustEqual Option(secretKey)
     }
     "handle null value for maxAge" in {
       JwtSession.getConfigMillis("play.http.session.maxAge") mustEqual None

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,12 +2,12 @@ import sbt._
 
 object Dependencies {
   object V {
-    val play = "2.6.16"
+    val play = "2.7.0"
     val playJson = "2.7.0"
     val json4s = "3.6.0"
     val circe = "0.10.0"
     val scalatest = "3.0.5"
-    val scalatestPlus = "3.1.2"
+    val scalatestPlus = "4.0.0"
     val jmockit = "1.24"
     val apacheCodec = "1.10"
     val bouncyCastle = "1.60"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ resolvers ++= Seq(
   "Typesafe repository releases" at "http://repo.typesafe.com/typesafe/releases/"
 )
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.6")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.0")
 
 addSbtPlugin("com.typesafe.sbt"  % "sbt-site"               % "1.3.0")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-ghpages"            % "0.6.2")


### PR DESCRIPTION
I added play 2.7 support to the library referencing #110 .

That issue only upped the play-json library but not the play framework itself.

Since Play 2.7 "really" deprecated global application state, I had to change the code to either have an instance of play.api.Configuration injected, or in the case of the companion objects I had to include it as an implicit parameter.  

I didn't know whether to tag this 1.2.0 or 1.1.1 because anyone that uses this library must have the configuration object injected in their controllers, and it might require some code changes for people upgrading. However since most of the library wasn't updated I tagged it as 1.1.1 leaving it to @pauldijou to decide the versioning.

I also removed all the deprecated functions to get configuration values which means that wrap function shouldn't be required anymore.

