### PR TITLE
Tut Fix, Play Examples Updated, and Regression Fix

### DIFF
--- a/docs/src/main/tut/_includes/tut/jwt-play-jwt-session.md
+++ b/docs/src/main/tut/_includes/tut/jwt-play-jwt-session.md
@@ -6,6 +6,12 @@ Provides an API similar to the Play [Session](https://www.playframework.com/docu
 
 ```tut
 import pdi.jwt.JwtSession
+import play.api.Configuration
+
+
+//In a real Play! App this should normally be injected in the constructor with @Inject()
+implicit val conf:Configuration = Configuration.reference
+
 // Let's create a session, it will automatically assign a default header. No
 // In your app, the default header would be generated from "application.conf" file
 // but here, it will just use the default values (which are all empty)
@@ -50,6 +56,12 @@ If you have implicit `Reads` and/or `Writes`, you can access and/or add data dir
 // First, creating the implicits
 import play.api.libs.json.Json
 import play.api.libs.functional.syntax._
+
+import play.api.Configuration
+
+//In a real Play! App this should normally be injected in the constructor with @Inject()
+implicit val conf:Configuration = Configuration.reference
+
 case class User(id: Long, name: String)
 implicit val formatUser = Json.format[User]
 
@@ -68,6 +80,11 @@ You can extract a `JwtSession` from a `RequestHeader`.
 import pdi.jwt._
 import pdi.jwt.JwtSession._
 import play.api.test.{FakeRequest, FakeHeaders}
+
+import play.api.Configuration
+
+//In a real Play! App this should normally be injected in the constructor with @Inject()
+implicit val conf:Configuration = Configuration.reference
 
 // Default JwtSession
 FakeRequest().jwtSession
@@ -89,6 +106,11 @@ There are also implicit helpers around `Result` to help you manipulate the sessi
 ```tut
 // Several functions will need an implicit RequestHeader
 // since this is the only way to read the headers of the Result
+import play.api.Configuration
+
+//In a real Play! App this should normally be injected in the constructor with @Inject()
+implicit val conf:Configuration = Configuration.reference
+
 implicit val implRequest = request
 
 // Let's begin by creating a Result

--- a/examples/play-angular-standalone/app/controllers/Application.scala
+++ b/examples/play-angular-standalone/app/controllers/Application.scala
@@ -7,11 +7,12 @@ import pdi.jwt.JwtSession._
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import play.api.mvc._
+import play.api.Configuration
 
 import scala.concurrent.{ ExecutionContext, Future }
 
 @Singleton
-class Application @Inject()(scc: SecuredControllerComponents, assets: AssetsFinder)(implicit ec: ExecutionContext)
+class Application @Inject()(scc: SecuredControllerComponents, assets: AssetsFinder)(implicit ec: ExecutionContext, conf:Configuration)
     extends SecuredController(scc) {
 
   private val passwords = Seq("red", "blue", "green")

--- a/examples/play-angular-standalone/app/controllers/Secured.scala
+++ b/examples/play-angular-standalone/app/controllers/Secured.scala
@@ -14,7 +14,7 @@ import scala.concurrent.{ ExecutionContext, Future }
 class AuthenticatedRequest[A](val user: User, request: Request[A]) extends WrappedRequest[A](request)
 
 class AuthenticatedActionBuilder @Inject()(parser: BodyParsers.Default)(implicit ec: ExecutionContext)
-    extends ActionBuilderImpl(parser) {
+  extends ActionBuilderImpl(parser) {
   override def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]): Future[Result] = {
     request.jwtSession.getAs[User]("user") match {
       case Some(user) =>
@@ -26,7 +26,7 @@ class AuthenticatedActionBuilder @Inject()(parser: BodyParsers.Default)(implicit
 }
 
 class AdminActionBuilder @Inject()(parser: BodyParsers.Default)(implicit ec: ExecutionContext)
-    extends ActionBuilderImpl(parser) {
+  extends ActionBuilderImpl(parser) {
   override def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]): Future[Result] = {
     request.jwtSession.getAs[User]("user") match {
       case Some(user) if user.isAdmin =>
@@ -40,15 +40,15 @@ class AdminActionBuilder @Inject()(parser: BodyParsers.Default)(implicit ec: Exe
 }
 
 case class SecuredControllerComponents @Inject()(
-    adminActionBuilder: AdminActionBuilder,
-    authenticatedActionBuilder: AuthenticatedActionBuilder,
-    actionBuilder: DefaultActionBuilder,
-    parsers: PlayBodyParsers,
-    messagesApi: MessagesApi,
-    langs: Langs,
-    fileMimeTypes: FileMimeTypes,
-    executionContext: scala.concurrent.ExecutionContext
-) extends ControllerComponents
+                                                  adminActionBuilder: AdminActionBuilder,
+                                                  authenticatedActionBuilder: AuthenticatedActionBuilder,
+                                                  actionBuilder: DefaultActionBuilder,
+                                                  parsers: PlayBodyParsers,
+                                                  messagesApi: MessagesApi,
+                                                  langs: Langs,
+                                                  fileMimeTypes: FileMimeTypes,
+                                                  executionContext: scala.concurrent.ExecutionContext
+                                                ) extends ControllerComponents
 
 class SecuredController @Inject()(scc: SecuredControllerComponents) extends AbstractController(scc) {
   def AdminAction: AdminActionBuilder                 = scc.adminActionBuilder

--- a/examples/play-angular-standalone/build.sbt
+++ b/examples/play-angular-standalone/build.sbt
@@ -10,5 +10,5 @@ routesGenerator := play.sbt.routes.RoutesKeys.InjectedRoutesGenerator
 
 libraryDependencies ++= Seq(
   guice,
-  "com.pauldijou"     %% "jwt-play" % "0.14.1"
+  "com.pauldijou"     %% "jwt-play" % "2.0.0"
 )

--- a/examples/play-angular-standalone/project/plugins.sbt
+++ b/examples/play-angular-standalone/project/plugins.sbt
@@ -1,4 +1,4 @@
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.6")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.0")

--- a/examples/play-angular/app/controllers/Application.scala
+++ b/examples/play-angular/app/controllers/Application.scala
@@ -1,17 +1,17 @@
 package controllers
 
-import javax.inject.{ Inject, Singleton }
-
+import javax.inject.{Inject, Singleton}
 import models.User
 import pdi.jwt.JwtSession._
+import play.api.Configuration
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import play.api.mvc._
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class Application @Inject()(scc: SecuredControllerComponents, assets: AssetsFinder)(implicit ec: ExecutionContext)
+class Application @Inject()(scc: SecuredControllerComponents, assets: AssetsFinder)(implicit ec: ExecutionContext, conf:Configuration)
     extends SecuredController(scc) {
 
   private val passwords = Seq("red", "blue", "green")

--- a/examples/play-angular/app/controllers/Secured.scala
+++ b/examples/play-angular/app/controllers/Secured.scala
@@ -1,19 +1,19 @@
 package controllers
 
 import javax.inject.Inject
-
 import models.User
 import pdi.jwt.JwtSession._
+import play.api.Configuration
 import play.api.http.FileMimeTypes
-import play.api.i18n.{ Langs, MessagesApi }
+import play.api.i18n.{Langs, MessagesApi}
 import play.api.mvc.Results._
 import play.api.mvc._
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 
 class AuthenticatedRequest[A](val user: User, request: Request[A]) extends WrappedRequest[A](request)
 
-class AuthenticatedActionBuilder @Inject()(parser: BodyParsers.Default)(implicit ec: ExecutionContext)
+class AuthenticatedActionBuilder @Inject()(parser: BodyParsers.Default)(implicit ec: ExecutionContext, conf:Configuration)
     extends ActionBuilderImpl(parser) {
   override def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]): Future[Result] = {
     request.jwtSession.getAs[User]("user") match {
@@ -25,7 +25,7 @@ class AuthenticatedActionBuilder @Inject()(parser: BodyParsers.Default)(implicit
   }
 }
 
-class AdminActionBuilder @Inject()(parser: BodyParsers.Default)(implicit ec: ExecutionContext)
+class AdminActionBuilder @Inject()(parser: BodyParsers.Default)(implicit ec: ExecutionContext, conf:Configuration)
     extends ActionBuilderImpl(parser) {
   override def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]): Future[Result] = {
     request.jwtSession.getAs[User]("user") match {

--- a/play/src/main/scala/JwtSession.scala
+++ b/play/src/main/scala/JwtSession.scala
@@ -83,7 +83,12 @@ object JwtSession extends JwtJsonImplicits with JwtPlayImplicits {
 
   def getConfigString(key:String)(implicit conf:Configuration) = conf.getOptional[String](key)
 
-  def getConfigMillis(key:String)(implicit conf:Configuration) = conf.getOptional[Long](key)
+  def getConfigMillis(key:String)(implicit conf:Configuration) =
+    if(conf.has(key)) {
+      Some(conf.getMillis(key))
+    } else {
+      None
+    }
 
   def REQUEST_HEADER_NAME(implicit conf:Configuration): String = getConfigString("play.http.session.jwtName").getOrElse("Authorization")
 


### PR DESCRIPTION
I fixed the tut markdown files, it just needed an implicit configuration in scope.

I fixed a regression in getConfigMillis because getOptional[Long] will not be able to read a configuration variable in the 30s format (which was used in the example project) .

I also updated both example play projects.