### PR TITLE
Remove Bouncycastle as the default provider fixes #52

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ libraryDependencies ++= Seq(
 
 ## Dependencies
 
-- `"org.bouncycastle" % "bcpkix-jdk15on"`
+- `"org.bouncycastle" % "bcpkix-jdk15on"` (test only)
 - `"commons-codec" % "commons-codec"` (only if Java 1.6 or 1.7)
 
 ## Algorithms

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,11 @@
-import sbt._
-import Keys._
-import Tests._
-import play.sbt.Play.autoImport._
-import PlayKeys._
 import Dependencies._
-import scala.sys.process._
 import com.typesafe.sbt.pgp.PgpKeys._
+import play.sbt.Play.autoImport._
+import sbt.Keys._
+import sbt.Tests._
+import sbt._
+
+import scala.sys.process._
 
 val previousVersion = "2.0.0"
 val buildVersion = "2.1.0"
@@ -240,7 +240,7 @@ lazy val argonautProject = project.in(file("json/argonaut"))
 
 def groupPlayTest(tests: Seq[TestDefinition], files: Seq[File]) = tests.map { t =>
   val options = ForkOptions().withRunJVMOptions(Vector(s"-javaagent:${jmockitPath(files)}"))
-  new Group(t.name, Seq(t), new SubProcess(options))
+  Group(t.name, Seq(t), SubProcess(options))
 }
 
 lazy val playProject = project.in(file("play"))

--- a/core/src/main/java/JwtArrayUtils.java
+++ b/core/src/main/java/JwtArrayUtils.java
@@ -1,0 +1,44 @@
+package pdi.jwt;
+
+public final class JwtArrayUtils {
+
+    private JwtArrayUtils() {}
+
+    /**
+     * A constant time equals comparison - does not terminate early if
+     * test will fail. For best results always pass the expected value
+     * as the first parameter.
+     *
+     * Ported from BouncyCastle to remove the need for a runtime dependency.
+     *
+     * @param expected first array
+     * @param supplied second array
+     * @return true if arrays equal, false otherwise.
+     */
+    public static boolean constantTimeAreEqual(byte[] expected, byte[] supplied)
+    {
+        if (expected == supplied)
+        {
+            return true;
+        }
+
+        if (expected == null || supplied == null)
+        {
+            return false;
+        }
+
+        if (expected.length != supplied.length)
+        {
+            return !JwtArrayUtils.constantTimeAreEqual(expected, expected);
+        }
+
+        int nonEqual = 0;
+
+        for (int i = 0; i != expected.length; i++)
+        {
+            nonEqual |= (expected[i] ^ supplied[i]);
+        }
+
+        return nonEqual == 0;
+    }
+}

--- a/core/src/test/scala/JwtSpec.scala
+++ b/core/src/test/scala/JwtSpec.scala
@@ -1,11 +1,9 @@
 package pdi.jwt
 
-import org.scalatest._
-
-import scala.util.{Success, Failure}
-
 import pdi.jwt.algorithms._
 import pdi.jwt.exceptions._
+
+import scala.util.Success
 
 class JwtSpec extends UnitSpec with Fixture {
   def battleTestEncode(d: DataEntryBase, key: String) = {

--- a/core/src/test/scala/JwtUtilsSpec.scala
+++ b/core/src/test/scala/JwtUtilsSpec.scala
@@ -1,7 +1,7 @@
 package pdi.jwt
 
-import java.security.{KeyPairGenerator, SecureRandom}
 import java.security.spec.ECGenParameterSpec
+import java.security.{KeyPairGenerator, SecureRandom}
 
 import pdi.jwt.exceptions.JwtSignatureFormatException
 
@@ -131,7 +131,7 @@ class JwtUtilsSpec extends UnitSpec {
 
       it("should be symmetric for generated tokens") {
         val ecGenSpec = new ECGenParameterSpec("P-521")
-        val generatorEC = KeyPairGenerator.getInstance(JwtUtils.ECDSA, JwtUtils.PROVIDER)
+        val generatorEC = KeyPairGenerator.getInstance(JwtUtils.ECDSA)
         generatorEC.initialize(ecGenSpec, new SecureRandom())
         val randomECKey = generatorEC.generateKeyPair()
         val header = """{"typ":"JWT","alg":"ES512"}"""

--- a/json/common/src/test/scala/JwtJsonCommonSpec.scala
+++ b/json/common/src/test/scala/JwtJsonCommonSpec.scala
@@ -1,10 +1,8 @@
 package pdi.jwt
 
-import org.scalatest._
-
-import scala.util.{Success, Failure}
-
 import pdi.jwt.exceptions._
+
+import scala.util.Success
 
 abstract class JwtJsonCommonSpec[J] extends UnitSpec with JsonCommonFixture[J] {
   def jwtJsonCommon: JwtJsonCommon[J, JwtHeader, JwtClaim]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -38,7 +38,7 @@ object Dependencies {
 
     val argonaut = "io.argonaut" %% "argonaut" % V.argonaut
 
-    val bouncyCastle = "org.bouncycastle" % "bcpkix-jdk15on" % V.bouncyCastle
+    val bouncyCastle = "org.bouncycastle" % "bcpkix-jdk15on" % V.bouncyCastle % "test"
 
     val scalatest = "org.scalatest" %% "scalatest" % V.scalatest % "test"
     val scalatestPlus = "org.scalatestplus.play" %% "scalatestplus-play" % V.scalatestPlus % "test"


### PR DESCRIPTION
Previously, the library placed an artificial constraint needing
the BouncyCastle provider to perform cryptographic functions
when it was not necessary to do so.

This commit removes the requirement to both require BouncyCastle
as the sole provider, as well as requiring the BouncyCastle
dependency at runtime.

If the user wishes to use BouncyCastle, they should add the provider
as is done in the tests. The library will automatically use
whatever the preferred provider is instead of BouncyCastle.