### PR TITLE
Add support for Scala 2.13.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,13 +41,15 @@ cleanScript := {
   "./scripts/clean.sh" !
 }
 
-val scala213 = "2.13.0-M5"
+val scala211 = "2.11.12"
+val scala212 = "2.12.8"
+val scala213 = "2.13.0"
 
 val baseSettings = Seq(
   organization := "com.pauldijou",
   version := buildVersion,
-  scalaVersion in ThisBuild := "2.12.7",
-  crossScalaVersions := Seq("2.12.7", "2.11.12", scala213),
+  scalaVersion in ThisBuild := scala212,
+  crossScalaVersions := Seq(scala211, scala212, scala213),
   crossVersion := CrossVersion.binary,
   autoAPIMappings := true,
   resolvers ++= Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   object V {
-    val scalatest = "3.0.6-SNAP6"
+    val scalatest = "3.0.7"
     val scalatestPlus = "4.0.0"
     val bouncyCastle = "1.60"
     val guice = "4.2.2"


### PR DESCRIPTION
- Support for Scala 2.13.0 (final release)
- Use `val` for all Scala versions
- Bump scalatest dependency to a stable release