### PR TITLE
Compile Java classes to Java 8 target

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,6 +60,7 @@ val baseSettings = Seq(
   Test / fork := true,
   Test / parallelExecution := false,
   scalacOptions in (Compile, doc) ++= Seq("-unchecked", "-deprecation"),
+  javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 )
 
 val publishSettings = Seq(


### PR DESCRIPTION
Since we compile classes by default with Java 11, the java
classes that are generated are versioned at 55. This breaks
compatibility with the majority of Java runtimes.

This commit introduces a compile target for java classes in the
project so that anyone running JRE8 or later will be able to
utilize these classes without running into compatibility issues.

Tested with javap to confirm using a Java11 compiler:

Before:
sbt -java-home /Library/Java/JavaVirtualMachines/openjdk-11.0.2.jdk/Contents/Home ";clean;compile"
...
$ javap -verbose core/target/scala-2.12/classes/pdi/jwt/JwtArrayUtils.class | grep "major"
  major version: 55

After:
sbt -java-home /Library/Java/JavaVirtualMachines/openjdk-11.0.2.jdk/Contents/Home ";clean;compile"
$ javap -verbose core/target/scala-2.12/classes/pdi/jwt/JwtArrayUtils.class | grep "major"
  major version: 52