### PR TITLE
Fix issue #132 Audience defined as Set is incompatible with some APIs

### DIFF
--- a/core/src/main/scala/JwtClaim.scala
+++ b/core/src/main/scala/JwtClaim.scala
@@ -25,10 +25,14 @@ class JwtClaim(
   val issuedAt: Option[Long],
   val jwtId: Option[String]
 ) {
+
+  private final def simplifyToSingular[A](set: Set[A]): Option[A] = 
+    if (set.size == 1) set.headOption else None
+
   def toJson: String = JwtUtils.mergeJson(JwtUtils.hashToJson(Seq(
     "iss" -> issuer,
     "sub" -> subject,
-    "aud" -> audience,
+    "aud" -> audience.flatMap(set => simplifyToSingular(set).orElse(Some(set))),
     "exp" -> expiration,
     "nbf" -> notBefore,
     "iat" -> issuedAt,

--- a/json/json4s-jackson/src/test/scala/Json4sJacksonSpec.scala
+++ b/json/json4s-jackson/src/test/scala/Json4sJacksonSpec.scala
@@ -14,7 +14,7 @@ class JwtJson4sJacksonSpec extends JwtJsonCommonSpec[JObject] with Json4sJackson
     it("should implicitly convert to JValue") {
       assertResult((
         ("iss" -> "me") ~
-        ("aud" -> Set("you")) ~
+        ("aud" -> Option("you")) ~
         ("sub" -> "something") ~
         ("exp" -> 15) ~
         ("nbf" -> 10) ~
@@ -28,6 +28,19 @@ class JwtJson4sJacksonSpec extends JwtJsonCommonSpec[JObject] with Json4sJackson
         ("alg" -> "HS256")
       ), "Claim") {
         JwtHeader(JwtAlgorithm.HS256).toJValue
+      }
+    }
+
+    it("should implicitly convert to JValue when audience is many") {
+      assertResult((
+        ("iss" -> "me") ~
+        ("aud" -> Set("you", "another")) ~
+        ("sub" -> "something") ~
+        ("exp" -> 15) ~
+        ("nbf" -> 10) ~
+        ("iat" -> 10)
+      ), "Claim") {
+        JwtClaim(audience = Some(Set("you", "another"))).by("me").about("something").issuedAt(10).startsAt(10).expiresAt(15).toJValue
       }
     }
   }

--- a/json/json4s-native/src/test/scala/Json4sNativeSpec.scala
+++ b/json/json4s-native/src/test/scala/Json4sNativeSpec.scala
@@ -14,7 +14,7 @@ class JwtJson4sNativeSpec extends JwtJsonCommonSpec[JObject] with Json4sNativeFi
     it("should implicitly convert to JValue") {
       assertResult((
         ("iss" -> "me") ~
-        ("aud" -> Set("you")) ~
+        ("aud" -> Option("you")) ~
         ("sub" -> "something") ~
         ("exp" -> 15) ~
         ("nbf" -> 10) ~
@@ -28,6 +28,19 @@ class JwtJson4sNativeSpec extends JwtJsonCommonSpec[JObject] with Json4sNativeFi
         ("alg" -> "HS256")
       ), "Claim") {
         JwtHeader(JwtAlgorithm.HS256).toJValue
+      }
+    }
+
+    it("should implicitly convert to JValue when audience is many") {
+      assertResult((
+        ("iss" -> "me") ~
+        ("aud" -> Set("you", "another")) ~
+        ("sub" -> "something") ~
+        ("exp" -> 15) ~
+        ("nbf" -> 10) ~
+        ("iat" -> 10)
+      ), "Claim") {
+        JwtClaim(audience = Some(Set("you", "another"))).by("me").about("something").issuedAt(10).startsAt(10).expiresAt(15).toJValue
       }
     }
   }

--- a/json/play-json/src/test/scala/JwtJsonSpec.scala
+++ b/json/play-json/src/test/scala/JwtJsonSpec.scala
@@ -12,7 +12,7 @@ class JwtJsonSpec extends JwtJsonCommonSpec[JsObject] with JsonFixture {
     it("should implicitly convert to JsValue") {
       assertResult(Json.obj(
         ("iss" -> "me"),
-        ("aud" -> Set("you")),
+        ("aud" -> Some("you")),
         ("sub" -> "something"),
         ("exp" -> 15),
         ("nbf" -> 10),
@@ -26,6 +26,19 @@ class JwtJsonSpec extends JwtJsonCommonSpec[JsObject] with JsonFixture {
         ("alg" -> "HS256")
       ), "Claim") {
         JwtHeader(JwtAlgorithm.HS256).toJsValue
+      }
+    }
+
+    it("should implicitly convert to JsValue when audience is many") {
+      assertResult(Json.obj(
+        ("iss" -> "me"),
+        ("aud" -> Set("you", "another")),
+        ("sub" -> "something"),
+        ("exp" -> 15),
+        ("nbf" -> 10),
+        ("iat" -> 10)
+      ), "Claim") {
+        JwtClaim(audience = Some(Set("you", "another"))).by("me").about("something").issuedAt(10).startsAt(10).expiresAt(15).toJsValue
       }
     }
 


### PR DESCRIPTION
When the audience value is a singular item, internally extract it from the set before serialization.

This fixes issue #132