### PR TITLE
Update circe to 0.12.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -181,7 +181,7 @@ lazy val circeProject = project.in(file("json/circe"))
   .settings(releaseSettings)
   .settings(
     name := "jwt-circe",
-    crossScalaVersions -= scala213,
+    crossScalaVersions := crossVersionLastTwo,
     libraryDependencies ++= Seq(Libs.circeCore, Libs.circeGeneric, Libs.circeParse)
   )
   .aggregate(jsonCommonProject)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
     val play = "2.7.3"
     val playJson = "2.7.4"
     val json4s = "3.6.6"
-    val circe = "0.11.1"
+    val circe = "0.12.1"
     val upickle = "0.7.5"
     val sprayJson = "1.3.5"
     val argonaut = "6.2.3"


### PR DESCRIPTION
- Circe 0.12 is now stable
- Drop support for 2.11 for `circeProject` as Circe dropped it already