### PR TITLE
Defer point of failure when algorithm is unknown

### DIFF
--- a/core/src/main/scala/Jwt.scala
+++ b/core/src/main/scala/Jwt.scala
@@ -578,7 +578,7 @@ trait JwtCore[H, C] {
   protected def validate(header: H, claim: C, signature: String, options: JwtOptions) {
     if (options.signature && !signature.isEmpty) {
       throw new JwtNonEmptySignatureException()
-    } else if (options.signature && !extractAlgorithm(header).isEmpty) {
+    } else if (options.signature && extractAlgorithm(header).isDefined && !options.allowUnknownAlgos) {
       throw new JwtNonEmptyAlgorithmException()
     }
 

--- a/core/src/main/scala/Jwt.scala
+++ b/core/src/main/scala/Jwt.scala
@@ -578,8 +578,11 @@ trait JwtCore[H, C] {
   protected def validate(header: H, claim: C, signature: String, options: JwtOptions) {
     if (options.signature && !signature.isEmpty) {
       throw new JwtNonEmptySignatureException()
-    } else if (options.signature && extractAlgorithm(header).isDefined && !options.allowUnknownAlgos) {
-      throw new JwtNonEmptyAlgorithmException()
+    } else if (options.signature) {
+      extractAlgorithm(header).foreach {
+        case JwtUnkwownAlgorithm(name) => throw new JwtNonSupportedAlgorithm(name)
+        case _                         => throw new JwtNonEmptyAlgorithmException()
+      }
     }
 
     validateTiming(claim, options)

--- a/core/src/main/scala/JwtAlgorithm.scala
+++ b/core/src/main/scala/JwtAlgorithm.scala
@@ -1,6 +1,7 @@
 package pdi.jwt
 
 import pdi.jwt.exceptions.JwtNonSupportedAlgorithm
+import pdi.jwt.algorithms.JwtUnkwownAlgorithm
 
 sealed trait JwtAlgorithm {
   def name: String
@@ -13,6 +14,9 @@ package algorithms {
   sealed trait JwtHmacAlgorithm extends JwtAlgorithm {}
   sealed trait JwtRSAAlgorithm extends JwtAsymmetricAlgorithm {}
   sealed trait JwtECDSAAlgorithm extends JwtAsymmetricAlgorithm {}
+  final case class JwtUnkwownAlgorithm(name: String) extends JwtAlgorithm {
+    def fullName: String = name
+  }
 }
 
 object JwtAlgorithm {
@@ -35,7 +39,7 @@ object JwtAlgorithm {
     case "ES256"       => ES256
     case "ES384"       => ES384
     case "ES512"       => ES512
-    case _             => throw new JwtNonSupportedAlgorithm(algo)
+    case other         => JwtUnkwownAlgorithm(other)
     // Missing PS256 PS384 PS512
   }
 

--- a/core/src/main/scala/JwtOptions.scala
+++ b/core/src/main/scala/JwtOptions.scala
@@ -4,8 +4,7 @@ case class JwtOptions(
   signature: Boolean = true,
   expiration: Boolean = true,
   notBefore: Boolean = true,
-  leeway: Long = 0, // in seconds
-  allowUnknownAlgos : Boolean = false
+  leeway: Long = 0 // in seconds
 )
 
 object JwtOptions {

--- a/core/src/main/scala/JwtOptions.scala
+++ b/core/src/main/scala/JwtOptions.scala
@@ -4,7 +4,8 @@ case class JwtOptions(
   signature: Boolean = true,
   expiration: Boolean = true,
   notBefore: Boolean = true,
-  leeway: Long = 0 // in seconds
+  leeway: Long = 0, // in seconds
+  allowUnknownAlgos : Boolean = false
 )
 
 object JwtOptions {

--- a/core/src/main/scala/JwtUtils.scala
+++ b/core/src/main/scala/JwtUtils.scala
@@ -96,7 +96,7 @@ object JwtUtils {
      .replaceAll("\n", "")
      .trim
   )
-  
+
   private def parsePrivateKey(key: String, keyAlgo: String) = {
     val spec = new PKCS8EncodedKeySpec(parseKey(key))
     KeyFactory.getInstance(keyAlgo).generatePrivate(spec)
@@ -143,6 +143,7 @@ object JwtUtils {
       case algo: JwtHmacAlgorithm => sign(data, new SecretKeySpec(bytify(key), algo.fullName), algo)
       case algo: JwtRSAAlgorithm => sign(data, parsePrivateKey(key, RSA), algo)
       case algo: JwtECDSAAlgorithm => sign(data, parsePrivateKey(key, ECDSA), algo)
+      case algo: JwtUnkwownAlgorithm => throw new JwtNonSupportedAlgorithm(algo.fullName)
     }
 
   /**
@@ -179,6 +180,7 @@ object JwtUtils {
       case algo: JwtHmacAlgorithm =>  verify(data, signature, new SecretKeySpec(bytify(key), algo.fullName), algo)
       case algo: JwtRSAAlgorithm => verify(data, signature, parsePublicKey(key, RSA), algo)
       case algo: JwtECDSAAlgorithm => verify(data, signature, parsePublicKey(key, ECDSA), algo)
+      case algo: JwtUnkwownAlgorithm => throw new JwtNonSupportedAlgorithm(algo.fullName)
     }
 
   /**

--- a/core/src/test/scala/JwtSpec.scala
+++ b/core/src/test/scala/JwtSpec.scala
@@ -265,12 +265,11 @@ class JwtSpec extends UnitSpec with Fixture {
 
     it("should invalidate wrong algos") {
       val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJXVEYifQ.e30"
-      val decoded = Jwt.decode(token)
-      assert(decoded.isFailure)
-      intercept[JwtNonEmptyAlgorithmException] { decoded.get }
+      assert(Jwt.decode(token).isFailure)
+      intercept[JwtNonEmptyAlgorithmException] { Jwt.decode(token).get }
     }
 
-    it("should decode tokens with unknown algos dpeending on options") {
+    it("should decode tokens with unknown algos depending on options") {
       val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJXVEYifQ.e30"
       val decoded = Jwt.decode(token, options = JwtOptions(allowUnknownAlgos = true))
       assert(decoded.isSuccess)

--- a/core/src/test/scala/JwtSpec.scala
+++ b/core/src/test/scala/JwtSpec.scala
@@ -266,12 +266,12 @@ class JwtSpec extends UnitSpec with Fixture {
     it("should invalidate wrong algos") {
       val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJXVEYifQ.e30"
       assert(Jwt.decode(token).isFailure)
-      intercept[JwtNonEmptyAlgorithmException] { Jwt.decode(token).get }
+      intercept[JwtNonSupportedAlgorithm] { Jwt.decode(token).get }
     }
 
     it("should decode tokens with unknown algos depending on options") {
       val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJXVEYifQ.e30"
-      val decoded = Jwt.decode(token, options = JwtOptions(allowUnknownAlgos = true))
+      val decoded = Jwt.decode(token, options = JwtOptions(signature = false))
       assert(decoded.isSuccess)
     }
 

--- a/core/src/test/scala/JwtSpec.scala
+++ b/core/src/test/scala/JwtSpec.scala
@@ -265,8 +265,15 @@ class JwtSpec extends UnitSpec with Fixture {
 
     it("should invalidate wrong algos") {
       val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJXVEYifQ.e30"
-      assert(Jwt.decode(token).isFailure)
-      intercept[JwtNonSupportedAlgorithm] { Jwt.decode(token).get }
+      val decoded = Jwt.decode(token)
+      assert(decoded.isFailure)
+      intercept[JwtNonEmptyAlgorithmException] { decoded.get }
+    }
+
+    it("should decode tokens with unknown algos dpeending on options") {
+      val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJXVEYifQ.e30"
+      val decoded = Jwt.decode(token, options = JwtOptions(allowUnknownAlgos = true))
+      assert(decoded.isSuccess)
     }
 
     it("should skip expiration validation depending on options") {


### PR DESCRIPTION
The point of this is to allows for users to decode tokens (without validation of the signature) even when the algorithm is not known to this library, but still fail when trying to sign/validate using an unknown algorithm.

