### PR TITLE
Throw ParsingFailure instead of NoSuchElementException in JwtCirce.parse

### DIFF
--- a/json/circe/src/main/scala/JwtCirce.scala
+++ b/json/circe/src/main/scala/JwtCirce.scala
@@ -13,7 +13,7 @@ import pdi.jwt.exceptions.JwtNonStringException
   * Implementation of `JwtCore` using `Json` from Circe.
   */
 trait JwtCirceParser[H, C] extends JwtJsonCommon[Json, H, C] {
-  protected def parse(value: String): Json = jawnParse(value).toOption.get
+  protected def parse(value: String): Json = jawnParse(value).fold(throw _, identity)
   protected def stringify(value: Json): String = value.asJson.noSpaces
   protected def getAlgorithm(header: Json): Option[JwtAlgorithm] = getAlg(header.hcursor)
 


### PR DESCRIPTION
I am seeing a `NoSuchElementException`. It is generally bad practice to throw these exceptions instead of more detailed exceptions. I think throwing the `ParseFailure` will be more descriptive than `None.get` for debugging issues with tokens.