### PR TITLE
Mark circe-generic as test only

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -182,7 +182,7 @@ lazy val circeProject = project.in(file("json/circe"))
   .settings(
     name := "jwt-circe",
     crossScalaVersions := crossVersionLastTwo,
-    libraryDependencies ++= Seq(Libs.circeCore, Libs.circeGeneric, Libs.circeParse)
+    libraryDependencies ++= Seq(Libs.circeCore, Libs.circeParse, Libs.circeGeneric % "test")
   )
   .aggregate(jsonCommonProject)
   .dependsOn(jsonCommonProject % "compile->compile;test->test")


### PR DESCRIPTION
The circe-generic dependency is only used in tests, it can therefore be
configured as a test dependency.