### PR TITLE
add or set content with play json writes implicits

### DIFF
--- a/json/play-json/src/main/scala/JwtJsonImplicits.scala
+++ b/json/play-json/src/main/scala/JwtJsonImplicits.scala
@@ -1,8 +1,7 @@
 package pdi.jwt
 
-import play.api.libs.json._
-import play.api.libs.functional.syntax._
 import pdi.jwt.exceptions.{JwtNonNumberException, JwtNonStringException, JwtNonStringSetOrStringException, JwtNonSupportedAlgorithm}
+import play.api.libs.json._
 
 trait JwtJsonImplicits {
   private def extractString(json: JsObject, fieldName: String): Option[String] = (json \ fieldName).toOption.flatMap {
@@ -79,6 +78,16 @@ trait JwtJsonImplicits {
 
   implicit class RichJwtClaim(claim: JwtClaim) {
     def toJsValue(): JsValue = jwtPlayJsonClaimWriter.writes(claim)
+
+    def +[A](a: A)(implicit writes: Writes[A]): JwtClaim = {
+      val s = Json.stringify(writes.writes(a))
+      claim + s
+    }
+
+    def withContent[A](a: A)(implicit writes: Writes[A]): JwtClaim = {
+      val s = Json.stringify(writes.writes(a))
+      claim.withContent(s)
+    }
   }
 
   implicit class RichJwtHeader(header: JwtHeader) {


### PR DESCRIPTION
as it is now i feel its a bit cumbersome when your jwt content is a bit more complex: 

we have a few jwt contents defined as case classes (different use cases for a jwt). just defining a writes for each and then directly adding it to the claim feels be a bit more ergonomic, so I made a quick extension to the JwtClaim class to use it like

```
case class Content()
implicit val cWrites: Writes[Content] = ....

val content = Content()
JwtClaim().expiresAt().withContent(content)
//or
JwtClaim().expiresAt() + content
```