### PR TITLE
Make JwtException an exception.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,9 +65,6 @@ val baseSettings = Seq(
   crossScalaVersions := crossVersionAll,
   crossVersion := CrossVersion.binary,
   autoAPIMappings := true,
-  resolvers ++= Seq(
-    "Typesafe repository releases" at "http://repo.typesafe.com/typesafe/releases/"
-  ),
   libraryDependencies ++= Seq(Libs.scalatest),
   Test / aggregate := false,
   Test / fork := true,

--- a/core/src/main/scala/JwtException.scala
+++ b/core/src/main/scala/JwtException.scala
@@ -2,38 +2,38 @@ package pdi.jwt.exceptions
 
 import pdi.jwt.JwtTime
 
-sealed trait JwtException
+sealed abstract class JwtException(message: String) extends RuntimeException(message)
 
-class JwtLengthException(message: String) extends RuntimeException(message) with JwtException
+class JwtLengthException(message: String) extends JwtException(message)
 
-class JwtValidationException(message: String) extends RuntimeException(message) with JwtException
+class JwtValidationException(message: String) extends JwtException(message)
 
-class JwtSignatureFormatException(message: String) extends RuntimeException(message) with JwtException
+class JwtSignatureFormatException(message: String) extends JwtException(message)
 
-class JwtEmptySignatureException() extends RuntimeException("No signature found inside the token while trying to verify it with a key.") with JwtException
+class JwtEmptySignatureException() extends JwtException("No signature found inside the token while trying to verify it with a key.")
 
-class JwtNonEmptySignatureException() extends RuntimeException("Non-empty signature found inside the token while trying to verify without a key.") with JwtException
+class JwtNonEmptySignatureException() extends JwtException("Non-empty signature found inside the token while trying to verify without a key.")
 
-class JwtEmptyAlgorithmException() extends RuntimeException("No algorithm found inside the token header while having a key to sign or verify it.") with JwtException
+class JwtEmptyAlgorithmException() extends JwtException("No algorithm found inside the token header while having a key to sign or verify it.")
 
-class JwtNonEmptyAlgorithmException() extends RuntimeException("Algorithm found inside the token header while trying to sign or verify without a key.") with JwtException
+class JwtNonEmptyAlgorithmException() extends JwtException("Algorithm found inside the token header while trying to sign or verify without a key.")
 
-class JwtExpirationException(expiration: Long) extends RuntimeException("The token is expired since " + JwtTime.format(expiration)) with JwtException
+class JwtExpirationException(expiration: Long) extends JwtException("The token is expired since " + JwtTime.format(expiration))
 
-class JwtNotBeforeException(notBefore: Long) extends RuntimeException("The token will only be valid after " + JwtTime.format(notBefore)) with JwtException
+class JwtNotBeforeException(notBefore: Long) extends JwtException("The token will only be valid after " + JwtTime.format(notBefore))
 
-class JwtNonSupportedAlgorithm(algo: String) extends RuntimeException(s"The algorithm [$algo] is not currently supported.") with JwtException
+class JwtNonSupportedAlgorithm(algo: String) extends JwtException(s"The algorithm [$algo] is not currently supported.")
 
-class JwtNonSupportedCurve(curve: String) extends RuntimeException(s"The curve [$curve] is not currently supported.") with JwtException
+class JwtNonSupportedCurve(curve: String) extends JwtException(s"The curve [$curve] is not currently supported.")
 
-class JwtNonStringException(key: String) extends RuntimeException(s"During JSON parsing, expected a String for key [$key]") with JwtException {
+class JwtNonStringException(key: String) extends JwtException(s"During JSON parsing, expected a String for key [$key]") {
   def getKey = key
 }
 
-class JwtNonStringSetOrStringException(key: String) extends RuntimeException(s"During JSON parsing, expected a Set[String] or String for key [$key]") with JwtException {
+class JwtNonStringSetOrStringException(key: String) extends JwtException(s"During JSON parsing, expected a Set[String] or String for key [$key]") {
   def getKey = key
 }
 
-class JwtNonNumberException(key: String) extends RuntimeException(s"During JSON parsing, expected a Number for key [$key]") with JwtException {
+class JwtNonNumberException(key: String) extends JwtException(s"During JSON parsing, expected a Number for key [$key]") {
   def getKey = key
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,14 +1,3 @@
-resolvers ++= Seq(
-  Resolver.url("bintray-sbt-plugin-releases",
-    url("http://dl.bintray.com/content/sbt/sbt-plugin-releases")
-  )(Resolver.ivyStylePatterns),
-  Resolver.url(
-  "tpolecat-sbt-plugin-releases",
-    url("http://dl.bintray.com/content/tpolecat/sbt-plugin-releases")
-  )(Resolver.ivyStylePatterns),
-  "Typesafe repository releases" at "http://repo.typesafe.com/typesafe/releases/"
-)
-
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
 
 addSbtPlugin("com.typesafe.sbt"  % "sbt-site"               % "1.3.0")


### PR DESCRIPTION
This makes `JwtException` an exception. It also removes unnecessary resolvers (the Typesafe one may not exist anymore, it doesn't seem to work at the moment which was causing the build to fail).