### PR TITLE
Fix spelling of JwtUnknownAlgorithm

### DIFF
--- a/core/src/main/scala/Jwt.scala
+++ b/core/src/main/scala/Jwt.scala
@@ -777,7 +777,7 @@ trait JwtCore[H, C] {
       }
 
       extractAlgorithm(header).foreach {
-        case JwtUnkwownAlgorithm(name) => throw new JwtNonSupportedAlgorithm(name)
+        case JwtUnknownAlgorithm(name) => throw new JwtNonSupportedAlgorithm(name)
         case _                         => throw new JwtNonEmptyAlgorithmException()
       }
     }

--- a/core/src/main/scala/JwtAlgorithm.scala
+++ b/core/src/main/scala/JwtAlgorithm.scala
@@ -1,6 +1,6 @@
 package pdi.jwt
 
-import pdi.jwt.algorithms.JwtUnkwownAlgorithm
+import pdi.jwt.algorithms.JwtUnknownAlgorithm
 
 sealed trait JwtAlgorithm {
   def name: String
@@ -13,7 +13,7 @@ package algorithms {
   sealed trait JwtHmacAlgorithm extends JwtAlgorithm {}
   sealed trait JwtRSAAlgorithm extends JwtAsymmetricAlgorithm {}
   sealed trait JwtECDSAAlgorithm extends JwtAsymmetricAlgorithm {}
-  final case class JwtUnkwownAlgorithm(name: String) extends JwtAlgorithm {
+  final case class JwtUnknownAlgorithm(name: String) extends JwtAlgorithm {
     def fullName: String = name
   }
 }
@@ -39,7 +39,7 @@ object JwtAlgorithm {
     case "ES256" => ES256
     case "ES384" => ES384
     case "ES512" => ES512
-    case other   => JwtUnkwownAlgorithm(other)
+    case other   => JwtUnknownAlgorithm(other)
     // Missing PS256 PS384 PS512
   }
 

--- a/core/src/main/scala/JwtUtils.scala
+++ b/core/src/main/scala/JwtUtils.scala
@@ -149,7 +149,7 @@ object JwtUtils {
       case algo: JwtHmacAlgorithm    => sign(data, new SecretKeySpec(bytify(key), algo.fullName), algo)
       case algo: JwtRSAAlgorithm     => sign(data, parsePrivateKey(key, RSA), algo)
       case algo: JwtECDSAAlgorithm   => sign(data, parsePrivateKey(key, ECDSA), algo)
-      case algo: JwtUnkwownAlgorithm => throw new JwtNonSupportedAlgorithm(algo.fullName)
+      case algo: JwtUnknownAlgorithm => throw new JwtNonSupportedAlgorithm(algo.fullName)
     }
 
   /** Alias to `sign` using a String data which will be converted to an array of bytes.
@@ -198,7 +198,7 @@ object JwtUtils {
         verify(data, signature, new SecretKeySpec(bytify(key), algo.fullName), algo)
       case algo: JwtRSAAlgorithm     => verify(data, signature, parsePublicKey(key, RSA), algo)
       case algo: JwtECDSAAlgorithm   => verify(data, signature, parsePublicKey(key, ECDSA), algo)
-      case algo: JwtUnkwownAlgorithm => throw new JwtNonSupportedAlgorithm(algo.fullName)
+      case algo: JwtUnknownAlgorithm => throw new JwtNonSupportedAlgorithm(algo.fullName)
     }
 
   /** Alias for `verify`


### PR DESCRIPTION
The error class `JwtUnknownAlgorithm` was spelled `JwtUnkwownAlgorithm`
