### PR TITLE
Add support for Ed25519 (EdDSA) signature algorithm.

### DIFF
--- a/core/src/main/scala/JwtAlgorithm.scala
+++ b/core/src/main/scala/JwtAlgorithm.scala
@@ -13,6 +13,7 @@ package algorithms {
   sealed trait JwtHmacAlgorithm extends JwtAlgorithm {}
   sealed trait JwtRSAAlgorithm extends JwtAsymmetricAlgorithm {}
   sealed trait JwtECDSAAlgorithm extends JwtAsymmetricAlgorithm {}
+  sealed trait JwtEdDSAAlgorithm extends JwtAsymmetricAlgorithm {}
   final case class JwtUnknownAlgorithm(name: String) extends JwtAlgorithm {
     def fullName: String = name
   }
@@ -28,18 +29,19 @@ object JwtAlgorithm {
     * @throws JwtNonSupportedAlgorithm in case the string doesn't match any known algorithm
     */
   def fromString(algo: String): JwtAlgorithm = algo match {
-    case "HMD5"  => HMD5
-    case "HS224" => HS224
-    case "HS256" => HS256
-    case "HS384" => HS384
-    case "HS512" => HS512
-    case "RS256" => RS256
-    case "RS384" => RS384
-    case "RS512" => RS512
-    case "ES256" => ES256
-    case "ES384" => ES384
-    case "ES512" => ES512
-    case other   => JwtUnknownAlgorithm(other)
+    case "HMD5"    => HMD5
+    case "HS224"   => HS224
+    case "HS256"   => HS256
+    case "HS384"   => HS384
+    case "HS512"   => HS512
+    case "RS256"   => RS256
+    case "RS384"   => RS384
+    case "RS512"   => RS512
+    case "ES256"   => ES256
+    case "ES384"   => ES384
+    case "ES512"   => ES512
+    case "Ed25519" => Ed25519
+    case other     => JwtUnknownAlgorithm(other)
     // Missing PS256 PS384 PS512
   }
 
@@ -59,11 +61,13 @@ object JwtAlgorithm {
   def allHmac(): Seq[algorithms.JwtHmacAlgorithm] = Seq(HMD5, HS224, HS256, HS384, HS512)
 
   def allAsymmetric(): Seq[algorithms.JwtAsymmetricAlgorithm] =
-    Seq(RS256, RS384, RS512, ES256, ES384, ES512)
+    Seq(RS256, RS384, RS512, ES256, ES384, ES512, Ed25519)
 
   def allRSA(): Seq[algorithms.JwtRSAAlgorithm] = Seq(RS256, RS384, RS512)
 
   def allECDSA(): Seq[algorithms.JwtECDSAAlgorithm] = Seq(ES256, ES384, ES512)
+
+  def allEdDSA(): Seq[algorithms.JwtEdDSAAlgorithm] = Seq(Ed25519)
 
   case object HMD5 extends algorithms.JwtHmacAlgorithm {
     def name = "HMD5"; def fullName = "HmacMD5"
@@ -97,5 +101,8 @@ object JwtAlgorithm {
   }
   case object ES512 extends algorithms.JwtECDSAAlgorithm {
     def name = "ES512"; def fullName = "SHA512withECDSA"
+  }
+  case object Ed25519 extends algorithms.JwtEdDSAAlgorithm {
+    def name = "Ed25519"; def fullName = "Ed25519"
   }
 }

--- a/core/src/main/scala/JwtUtils.scala
+++ b/core/src/main/scala/JwtUtils.scala
@@ -14,7 +14,6 @@ object JwtUtils {
   val RSA = "RSA"
   val ECDSA = "EC"
   val EdDSA = "EdDSA"
-  val Ed25519 = "Ed25519"
 
   /** Convert an array of bytes to its corresponding string using the default encoding.
     *

--- a/core/src/main/scala/JwtUtils.scala
+++ b/core/src/main/scala/JwtUtils.scala
@@ -13,6 +13,7 @@ object JwtUtils {
   val ENCODING = "UTF-8"
   val RSA = "RSA"
   val ECDSA = "EC"
+  val EdDSA = "EdDSA"
 
   /** Convert an array of bytes to its corresponding string using the default encoding.
     *
@@ -136,6 +137,7 @@ object JwtUtils {
       case _: JwtRSAAlgorithm => signer.sign
       case algorithm: JwtECDSAAlgorithm =>
         transcodeSignatureToConcat(signer.sign, getSignatureByteArrayLength(algorithm))
+      case _: JwtEdDSAAlgorithm => signer.sign
     }
   }
 
@@ -149,6 +151,7 @@ object JwtUtils {
       case algo: JwtHmacAlgorithm    => sign(data, new SecretKeySpec(bytify(key), algo.fullName), algo)
       case algo: JwtRSAAlgorithm     => sign(data, parsePrivateKey(key, RSA), algo)
       case algo: JwtECDSAAlgorithm   => sign(data, parsePrivateKey(key, ECDSA), algo)
+      case algo: JwtEdDSAAlgorithm   => sign(data, parsePrivateKey(key, EdDSA), algo)
       case algo: JwtUnknownAlgorithm => throw new JwtNonSupportedAlgorithm(algo.fullName)
     }
 
@@ -182,6 +185,7 @@ object JwtUtils {
     algorithm match {
       case _: JwtRSAAlgorithm   => signer.verify(signature)
       case _: JwtECDSAAlgorithm => signer.verify(transcodeSignatureToDER(signature))
+      case _: JwtEdDSAAlgorithm => signer.verify(signature)
     }
   }
 
@@ -198,6 +202,7 @@ object JwtUtils {
         verify(data, signature, new SecretKeySpec(bytify(key), algo.fullName), algo)
       case algo: JwtRSAAlgorithm     => verify(data, signature, parsePublicKey(key, RSA), algo)
       case algo: JwtECDSAAlgorithm   => verify(data, signature, parsePublicKey(key, ECDSA), algo)
+      case algo: JwtEdDSAAlgorithm   => verify(data, signature, parsePublicKey(key, EdDSA), algo)
       case algo: JwtUnknownAlgorithm => throw new JwtNonSupportedAlgorithm(algo.fullName)
     }
 

--- a/core/src/main/scala/JwtUtils.scala
+++ b/core/src/main/scala/JwtUtils.scala
@@ -14,6 +14,7 @@ object JwtUtils {
   val RSA = "RSA"
   val ECDSA = "EC"
   val EdDSA = "EdDSA"
+  val Ed25519 = "Ed25519"
 
   /** Convert an array of bytes to its corresponding string using the default encoding.
     *

--- a/core/src/test/scala/Fixture.scala
+++ b/core/src/test/scala/Fixture.scala
@@ -52,7 +52,7 @@ trait ClockFixture {
   val validTimeMillis: Long = validTime * 1000
   val validTimeClock: Clock = fixedUTC(validTimeMillis)
 
-  val ecCurveName = "secp521r1";
+  val ecCurveName = "secp521r1"
 }
 
 trait Fixture extends ClockFixture {
@@ -61,6 +61,8 @@ trait Fixture extends ClockFixture {
   if (Security.getProvider("BC") == null) {
     Security.addProvider(new BouncyCastleProvider())
   }
+
+  val Ed25519 = "Ed25519"
 
   val secretKey =
     "AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"
@@ -174,7 +176,7 @@ b5VoYLNsdvZhqjVFTrYNEuhTJFYCF7jAiZLYvYm0C99BqcJnJPl7JjWynoNHNKw3
   val privateKeyEd25519 = "MC4CAQAwBQYDK2VwBCIEIHf3EQMqRKbBYOEjmrRm6Zu5hIYombr3DoWaRjZqK7uv"
   val publicKeyEd25519 = "MCowBQYDK2VwAyEAMGx9f797iAEdcI/QULMQFxgnt3ANZAqlTHavvAf3nD4="
 
-  val generatorEd25519 = KeyPairGenerator.getInstance(JwtUtils.Ed25519)
+  val generatorEd25519 = KeyPairGenerator.getInstance(Ed25519)
   val randomEd25519Key = generatorEd25519.generateKeyPair()
 
   val data = Seq(

--- a/core/src/test/scala/Fixture.scala
+++ b/core/src/test/scala/Fixture.scala
@@ -171,6 +171,12 @@ b5VoYLNsdvZhqjVFTrYNEuhTJFYCF7jAiZLYvYm0C99BqcJnJPl7JjWynoNHNKw3
     )
   }
 
+  val privateKeyEd25519 = "MC4CAQAwBQYDK2VwBCIEIHf3EQMqRKbBYOEjmrRm6Zu5hIYombr3DoWaRjZqK7uv"
+  val publicKeyEd25519 = "MCowBQYDK2VwAyEAMGx9f797iAEdcI/QULMQFxgnt3ANZAqlTHavvAf3nD4="
+
+  val generatorEd25519 = KeyPairGenerator.getInstance(JwtUtils.EdDSA)
+  val randomEd25519Key = generatorEd25519.generateKeyPair()
+
   val data = Seq(
     DataEntry(
       JwtAlgorithm.HMD5,
@@ -247,6 +253,16 @@ b5VoYLNsdvZhqjVFTrYNEuhTJFYCF7jAiZLYvYm0C99BqcJnJPl7JjWynoNHNKw3
       JwtHeader(JwtAlgorithm.ES512, "JWT"),
       "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzUxMiJ9",
       "MEUCICcluU9j5N40Mcr_Mo5_r5KVexcgrXH0LMVC_k1EPswPAiEA-8W2vz2bVZCzPv-S6CNDlbxNktEkOtTAg0XXiZ0ghLk"
+    )
+  ).map(setToken)
+
+  val dataEdDSA = Seq(
+    DataEntry(
+      JwtAlgorithm.Ed25519,
+      """{"typ":"JWT","alg":"Ed25519"}""",
+      JwtHeader(JwtAlgorithm.Ed25519, "JWT"),
+      "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZDI1NTE5In0",
+      "Y1L7qIIxk022Bi6RfybVXRI1YrTmchD8gc6ExiGFoHMyNTamrmsbRQi7EHF2ha4vSvuK8cFH2e89k4c8T0eGBA"
     )
   ).map(setToken)
 }

--- a/core/src/test/scala/Fixture.scala
+++ b/core/src/test/scala/Fixture.scala
@@ -174,7 +174,7 @@ b5VoYLNsdvZhqjVFTrYNEuhTJFYCF7jAiZLYvYm0C99BqcJnJPl7JjWynoNHNKw3
   val privateKeyEd25519 = "MC4CAQAwBQYDK2VwBCIEIHf3EQMqRKbBYOEjmrRm6Zu5hIYombr3DoWaRjZqK7uv"
   val publicKeyEd25519 = "MCowBQYDK2VwAyEAMGx9f797iAEdcI/QULMQFxgnt3ANZAqlTHavvAf3nD4="
 
-  val generatorEd25519 = KeyPairGenerator.getInstance(JwtUtils.EdDSA)
+  val generatorEd25519 = KeyPairGenerator.getInstance(JwtUtils.Ed25519)
   val randomEd25519Key = generatorEd25519.generateKeyPair()
 
   val data = Seq(


### PR DESCRIPTION
This add support to jwt-scala for the `ed25519` algorithm.

The [Ed25519 public-key signature algorithm](https://ed25519.cr.yp.to/) is highly secure and much faster than RSA or ECDSA.

From the Medium post [A Real World Comparison of the SSH Key Algorithms](https://nbeguier.medium.com/a-real-world-comparison-of-the-ssh-key-algorithms-b26b0b31bfd9):
>* Ed25519 is probably the strongest mathematically (and also the fastest), but not yet widely supported. At least 256 bits long.
>* RSA is the best bet if you can’t use Ed25519. At least 3072 bits long.

From the Medium post [Upgrade your SSH Key to Ed25519](https://medium.com/risan/upgrade-your-ssh-key-to-ed25519-c6e8d60d3c54):
>* 🚨 DSA: It’s unsafe and even no longer supported since OpenSSH version 7, you need to upgrade it!
>* ⚠️ RSA: It depends on key size. If it has 3072 or 4096-bit length, then you’re good. Less than that, you probably want to upgrade it. The 1024-bit length is even considered unsafe.
>* 👀 ECDSA: It depends on how well your machine can generate a random number that will be used to create a signature. There’s also a trustworthiness concern on the NIST curves that being used by ECDSA.
>* ✅ Ed25519: It’s the most recommended public-key algorithm available today!
