### PR TITLE
Remove throws

### DIFF
--- a/core/src/main/scala/Jwt.scala
+++ b/core/src/main/scala/Jwt.scala
@@ -770,7 +770,7 @@ trait JwtCore[H, C] {
   }
 
   // Validation when no key and no algorithm (or unknown)
-  protected def validate(header: H, claim: C, signature: String, options: JwtOptions) = {
+  protected def validate(header: H, claim: C, signature: String, options: JwtOptions): Unit = {
     if (options.signature) {
       if (!signature.isEmpty) {
         throw new JwtNonEmptySignatureException()
@@ -782,7 +782,7 @@ trait JwtCore[H, C] {
       }
     }
 
-    validateTiming(claim, options)
+    validateTiming(claim, options).get
   }
 
   // Validation when both key and algorithm
@@ -813,7 +813,7 @@ trait JwtCore[H, C] {
         throw new JwtValidationException("Invalid signature for this token or wrong algorithm.")
       }
     }
-    validateTiming(claim, options)
+    validateTiming(claim, options).get
   }
 
   // Generic validation on String Key for HMAC algorithms

--- a/core/src/main/scala/JwtPureScala.scala
+++ b/core/src/main/scala/JwtPureScala.scala
@@ -1,7 +1,8 @@
 package pdi.jwt
 
-import scala.util.matching.Regex
 import java.time.Clock
+import scala.util.matching.Regex
+import scala.util.Try
 
 /** Test implementation of [[JwtCore]] using only Strings. Most of the time, you should use a lib
   * implementing JSON and shouldn't be using this object. But just in case you need pure Scala support,
@@ -77,17 +78,21 @@ object Jwt extends JwtCore[JwtHeader, JwtClaim] {
     clearStart(clearEnd(clearMiddle(dirtyJson)))
   }
 
-  protected def parseHeader(header: String): JwtHeader = JwtHeader(extractAlgorithm(header))
+  protected def parseHeader(header: String): Try[JwtHeader] = Try(
+    JwtHeader(extractAlgorithm(header))
+  )
 
-  protected def parseClaim(claim: String): JwtClaim =
-    JwtClaim(
-      content = clearAll(claim),
-      issuer = extractIssuer(claim),
-      subject = extractSubject(claim),
-      expiration = extractExpiration(claim),
-      notBefore = extractNotBefore(claim),
-      issuedAt = extractIssuedAt(claim),
-      jwtId = extractJwtId(claim)
+  protected def parseClaim(claim: String): Try[JwtClaim] =
+    Try(
+      JwtClaim(
+        content = clearAll(claim),
+        issuer = extractIssuer(claim),
+        subject = extractSubject(claim),
+        expiration = extractExpiration(claim),
+        notBefore = extractNotBefore(claim),
+        issuedAt = extractIssuedAt(claim),
+        jwtId = extractJwtId(claim)
+      )
     )
 
   protected def headerToJson(header: JwtHeader): String = header.toJson
@@ -99,8 +104,8 @@ object Jwt extends JwtCore[JwtHeader, JwtClaim] {
 }
 
 class Jwt private (override val clock: Clock) extends JwtCore[JwtHeader, JwtClaim] {
-  protected def parseHeader(header: String): JwtHeader = Jwt.parseHeader(header)
-  protected def parseClaim(claim: String): JwtClaim = Jwt.parseClaim(claim)
+  protected def parseHeader(header: String): Try[JwtHeader] = Jwt.parseHeader(header)
+  protected def parseClaim(claim: String): Try[JwtClaim] = Jwt.parseClaim(claim)
 
   protected def extractAlgorithm(header: JwtHeader): Option[JwtAlgorithm] = header.algorithm
   protected def extractExpiration(claim: JwtClaim): Option[Long] = claim.expiration

--- a/core/src/main/scala/JwtTime.scala
+++ b/core/src/main/scala/JwtTime.scala
@@ -38,7 +38,7 @@ object JwtTime {
   def nowIsBetweenSeconds(start: Option[Long], end: Option[Long])(implicit clock: Clock): Boolean =
     nowIsBetween(start.map(_ * 1000), end.map(_ * 1000))
 
-  /** Test if the current time is between the two params and throw an exception if we don't have `start` <= now < `end`
+  /** Test if the current time is between the two params and return a Failure if we don't have `start` <= now < `end`
     *
     * @param start if set, the instant that must be before now (in millis)
     * @param end if set, the instant that must be after now (in millis)
@@ -61,8 +61,8 @@ object JwtTime {
     *
     * @param start if set, the instant that must be before now (in seconds)
     * @param end if set, the instant that must be after now (in seconds)
-    * @throws JwtNotBeforeException if `start` > now
-    * @throws JwtExpirationException if now > `end`
+    * @return Failure(JwtNotBeforeException) if `start` > now
+    * @return Failure(JwtExpirationException) if now > `end`
     */
   def validateNowIsBetweenSeconds(start: Option[Long], end: Option[Long])(implicit
       clock: Clock

--- a/core/src/main/scala/JwtUtils.scala
+++ b/core/src/main/scala/JwtUtils.scala
@@ -187,10 +187,10 @@ object JwtUtils {
   ): Boolean = algorithm match {
     case algo: JwtHmacAlgorithm =>
       verify(data, signature, new SecretKeySpec(bytify(key), algo.fullName), algo)
-    case algo: JwtRSAAlgorithm     => verify(data, signature, parsePublicKey(key, RSA), algo)
-    case algo: JwtECDSAAlgorithm   => verify(data, signature, parsePublicKey(key, ECDSA), algo)
-    case algo: JwtEdDSAAlgorithm   => verify(data, signature, parsePublicKey(key, EdDSA), algo)
-    case algo: JwtUnknownAlgorithm => throw new JwtNonSupportedAlgorithm(algo.fullName)
+    case algo: JwtRSAAlgorithm   => verify(data, signature, parsePublicKey(key, RSA), algo)
+    case algo: JwtECDSAAlgorithm => verify(data, signature, parsePublicKey(key, ECDSA), algo)
+    case algo: JwtEdDSAAlgorithm => verify(data, signature, parsePublicKey(key, EdDSA), algo)
+    case _: JwtUnknownAlgorithm  => false // Unsupported algorithm
   }
 
   /** Alias for `verify`

--- a/core/src/test/scala/JwtSpec.scala
+++ b/core/src/test/scala/JwtSpec.scala
@@ -177,29 +177,26 @@ class JwtSpec extends munit.FunSuite with Fixture {
   test("should validate correct tokens") {
 
     data foreach { d =>
-      assertEquals(
-        (),
-        validTimeJwt.validate(d.token, secretKey, JwtAlgorithm.allHmac()),
+      assert(
+        validTimeJwt.validate(d.token, secretKey, JwtAlgorithm.allHmac()).isSuccess,
         d.algo.fullName
       )
       assert(validTimeJwt.isValid(d.token, secretKey, JwtAlgorithm.allHmac()), d.algo.fullName)
-      assertEquals((), validTimeJwt.validate(d.token, secretKeyOf(d.algo)), d.algo.fullName)
+      assert(validTimeJwt.validate(d.token, secretKeyOf(d.algo)).isSuccess, d.algo.fullName)
       assert(validTimeJwt.isValid(d.token, secretKeyOf(d.algo)), d.algo.fullName)
     }
 
     dataRSA foreach { d =>
-      assertEquals(
-        (),
-        validTimeJwt.validate(d.token, publicKeyRSA, JwtAlgorithm.allRSA()),
+      assert(
+        validTimeJwt.validate(d.token, publicKeyRSA, JwtAlgorithm.allRSA()).isSuccess,
         d.algo.fullName
       )
       assert(validTimeJwt.isValid(d.token, publicKeyRSA, JwtAlgorithm.allRSA()), d.algo.fullName)
     }
 
     dataEdDSA foreach { d =>
-      assertEquals(
-        (),
-        validTimeJwt.validate(d.token, publicKeyEd25519, JwtAlgorithm.allEdDSA()),
+      assert(
+        validTimeJwt.validate(d.token, publicKeyEd25519, JwtAlgorithm.allEdDSA()).isSuccess,
         d.algo.fullName
       )
       assert(
@@ -229,7 +226,7 @@ class JwtSpec extends munit.FunSuite with Fixture {
     val tokens = Seq("1", "abcde", "", "a.b.c.d")
 
     tokens.foreach { token =>
-      intercept[JwtLengthException] { Jwt.validate(token, secretKey, JwtAlgorithm.allHmac()) }
+      intercept[JwtLengthException] { Jwt.validate(token, secretKey, JwtAlgorithm.allHmac()).get }
       assert(!Jwt.isValid(token, secretKey, JwtAlgorithm.allHmac()), token)
     }
   }
@@ -239,7 +236,7 @@ class JwtSpec extends munit.FunSuite with Fixture {
 
     tokens.foreach { token =>
       intercept[IllegalArgumentException] {
-        Jwt.validate(token, secretKey, JwtAlgorithm.allHmac())
+        Jwt.validate(token, secretKey, JwtAlgorithm.allHmac()).get
       }
       assert(!Jwt.isValid(token, secretKey, JwtAlgorithm.allHmac()), token)
     }
@@ -248,21 +245,21 @@ class JwtSpec extends munit.FunSuite with Fixture {
   test("should invalidate expired tokens") {
     data foreach { d =>
       intercept[JwtExpirationException] {
-        afterExpirationJwt.validate(d.token, secretKey, JwtAlgorithm.allHmac())
+        afterExpirationJwt.validate(d.token, secretKey, JwtAlgorithm.allHmac()).get
       }
       assert(
         !afterExpirationJwt.isValid(d.token, secretKey, JwtAlgorithm.allHmac()),
         d.algo.fullName
       )
       intercept[JwtExpirationException] {
-        afterExpirationJwt.validate(d.token, secretKeyOf(d.algo))
+        afterExpirationJwt.validate(d.token, secretKeyOf(d.algo)).get
       }
       assert(!afterExpirationJwt.isValid(d.token, secretKeyOf(d.algo)), d.algo.fullName)
     }
 
     dataRSA foreach { d =>
       intercept[JwtExpirationException] {
-        afterExpirationJwt.validate(d.token, publicKeyRSA, JwtAlgorithm.allRSA())
+        afterExpirationJwt.validate(d.token, publicKeyRSA, JwtAlgorithm.allRSA()).get
       }
       assert(
         !afterExpirationJwt.isValid(d.token, publicKeyRSA, JwtAlgorithm.allRSA()),
@@ -272,7 +269,7 @@ class JwtSpec extends munit.FunSuite with Fixture {
 
     dataEdDSA foreach { d =>
       intercept[JwtExpirationException] {
-        afterExpirationJwt.validate(d.token, publicKeyEd25519, JwtAlgorithm.allEdDSA())
+        afterExpirationJwt.validate(d.token, publicKeyEd25519, JwtAlgorithm.allEdDSA()).get
       }
       assert(
         !afterExpirationJwt.isValid(d.token, publicKeyEd25519, JwtAlgorithm.allEdDSA()),
@@ -317,10 +314,12 @@ class JwtSpec extends munit.FunSuite with Fixture {
       val token = beforeNotBeforeJwt.encode(claimNotBefore, secretKey, d.algo)
 
       intercept[JwtNotBeforeException] {
-        beforeNotBeforeJwt.validate(token, secretKey, JwtAlgorithm.allHmac())
+        beforeNotBeforeJwt.validate(token, secretKey, JwtAlgorithm.allHmac()).get
       }
       assert(!beforeNotBeforeJwt.isValid(token, secretKey, JwtAlgorithm.allHmac()), d.algo.fullName)
-      intercept[JwtNotBeforeException] { beforeNotBeforeJwt.validate(token, secretKeyOf(d.algo)) }
+      intercept[JwtNotBeforeException] {
+        beforeNotBeforeJwt.validate(token, secretKeyOf(d.algo)).get
+      }
       assert(!beforeNotBeforeJwt.isValid(token, secretKeyOf(d.algo)), d.algo.fullName)
     }
 
@@ -329,7 +328,7 @@ class JwtSpec extends munit.FunSuite with Fixture {
       val token = beforeNotBeforeJwt.encode(claimNotBefore, privateKeyRSA, d.algo)
 
       intercept[JwtNotBeforeException] {
-        beforeNotBeforeJwt.validate(token, publicKeyRSA, JwtAlgorithm.allRSA())
+        beforeNotBeforeJwt.validate(token, publicKeyRSA, JwtAlgorithm.allRSA()).get
       }
       assert(
         !beforeNotBeforeJwt.isValid(token, publicKeyRSA, JwtAlgorithm.allRSA()),
@@ -342,7 +341,7 @@ class JwtSpec extends munit.FunSuite with Fixture {
       val token = beforeNotBeforeJwt.encode(claimNotBefore, privateKeyEd25519, d.algo)
 
       intercept[JwtNotBeforeException] {
-        beforeNotBeforeJwt.validate(token, publicKeyEd25519, JwtAlgorithm.allEdDSA())
+        beforeNotBeforeJwt.validate(token, publicKeyEd25519, JwtAlgorithm.allEdDSA()).get
       }
       assert(
         !beforeNotBeforeJwt.isValid(token, publicKeyEd25519, JwtAlgorithm.allEdDSA()),
@@ -372,7 +371,7 @@ class JwtSpec extends munit.FunSuite with Fixture {
       val token = beforeNotBeforeJwt.encode(claimNotBefore, privateKeyRSA, d.algo)
 
       intercept[JwtNotBeforeException] {
-        beforeNotBeforeJwt.validate(token, publicKeyRSA, JwtAlgorithm.allRSA())
+        beforeNotBeforeJwt.validate(token, publicKeyRSA, JwtAlgorithm.allRSA()).get
       }
       assert(
         !beforeNotBeforeJwt.isValid(token, publicKeyRSA, JwtAlgorithm.allRSA()),
@@ -385,7 +384,7 @@ class JwtSpec extends munit.FunSuite with Fixture {
       val token = beforeNotBeforeJwt.encode(claimNotBefore, privateKeyEd25519, d.algo)
 
       intercept[JwtNotBeforeException] {
-        beforeNotBeforeJwt.validate(token, publicKeyEd25519, JwtAlgorithm.allEdDSA())
+        beforeNotBeforeJwt.validate(token, publicKeyEd25519, JwtAlgorithm.allEdDSA()).get
       }
       assert(
         !beforeNotBeforeJwt.isValid(token, publicKeyEd25519, JwtAlgorithm.allEdDSA()),
@@ -397,7 +396,7 @@ class JwtSpec extends munit.FunSuite with Fixture {
   test("should invalidate wrong keys") {
     data foreach { d =>
       intercept[JwtValidationException] {
-        validTimeJwt.validate(d.token, "wrong key", JwtAlgorithm.allHmac())
+        validTimeJwt.validate(d.token, "wrong key", JwtAlgorithm.allHmac()).get
       }
       assert(!validTimeJwt.isValid(d.token, "wrong key", JwtAlgorithm.allHmac()), d.algo.fullName)
     }
@@ -414,7 +413,7 @@ class JwtSpec extends munit.FunSuite with Fixture {
   test("should fail on non-exposed algorithms") {
     data foreach { d =>
       intercept[JwtValidationException] {
-        validTimeJwt.validate(d.token, secretKey, Seq.empty[JwtHmacAlgorithm])
+        validTimeJwt.validate(d.token, secretKey, Seq.empty[JwtHmacAlgorithm]).get
       }
       assert(
         !validTimeJwt.isValid(d.token, secretKey, Seq.empty[JwtHmacAlgorithm]),
@@ -424,14 +423,14 @@ class JwtSpec extends munit.FunSuite with Fixture {
 
     data foreach { d =>
       intercept[JwtValidationException] {
-        validTimeJwt.validate(d.token, secretKey, JwtAlgorithm.allRSA())
+        validTimeJwt.validate(d.token, secretKey, JwtAlgorithm.allRSA()).get
       }
       assert(!validTimeJwt.isValid(d.token, secretKey, JwtAlgorithm.allRSA()), d.algo.fullName)
     }
 
     dataRSA foreach { d =>
       intercept[JwtValidationException] {
-        validTimeJwt.validate(d.token, publicKeyRSA, JwtAlgorithm.allHmac())
+        validTimeJwt.validate(d.token, publicKeyRSA, JwtAlgorithm.allHmac()).get
       }
       assert(!validTimeJwt.isValid(d.token, publicKeyRSA, JwtAlgorithm.allHmac()), d.algo.fullName)
     }

--- a/docs/src/main/mdoc/jwt-core-jwt.md
+++ b/docs/src/main/mdoc/jwt-core-jwt.md
@@ -80,9 +80,11 @@ Jwt.decode(Jwt.encode(JwtClaim().startsIn(5)))
 
 ### Validating
 
-If you only want to check if a token is valid without decoding it. You have two options: `validate` functions that will throw the exceptions we saw in the decoding section, so you know what went wrong, or `isValid` functions that will return a boolean in case you don't care about the actual error and don't want to bother with catching exception.
+If you only want to check if a token is valid without decoding it. You have two options: `validate` functions that
+return a `Try[Unit]` with the exceptions we saw in the decoding section, so you know what went wrong,
+or `isValid` functions that will return a boolean in case you don't care about the actual error.
 
-```scala mdoc:crash
+```scala mdoc
 // All good
 Jwt.validate(token, "secretKey", Seq(JwtAlgorithm.HS256))
 Jwt.isValid(token, "secretKey", Seq(JwtAlgorithm.HS256))

--- a/json/circe/src/main/scala/JwtCirce.scala
+++ b/json/circe/src/main/scala/JwtCirce.scala
@@ -6,11 +6,12 @@ import io.circe.jawn.{parse => jawnParse}
 import java.time.Clock
 
 import scala.annotation.nowarn
+import scala.util.{Failure, Try, Success}
 
 /** Implementation of `JwtCore` using `Json` from Circe.
   */
 trait JwtCirceParser[H, C] extends JwtJsonCommon[Json, H, C] {
-  protected def parse(value: String): Json = jawnParse(value).fold(throw _, identity)
+  protected def parse(value: String): Try[Json] = jawnParse(value).fold(Failure(_), Success(_))
   protected def stringify(value: Json): String = value.asJson.noSpaces
   protected def getAlgorithm(header: Json): Option[JwtAlgorithm] = getAlg(header.hcursor)
 
@@ -24,49 +25,53 @@ trait JwtCirceParser[H, C] extends JwtJsonCommon[Json, H, C] {
 object JwtCirce extends JwtCirceParser[JwtHeader, JwtClaim] {
   def apply(clock: Clock): JwtCirce = new JwtCirce(clock)
 
-  def parseHeader(header: String): JwtHeader = parseHeaderHelp(header)
-  def parseClaim(claim: String): JwtClaim = parseClaimHelp(claim)
+  def parseHeader(header: String): Try[JwtHeader] = parseHeaderHelp(header)
+  def parseClaim(claim: String): Try[JwtClaim] = parseClaimHelp(claim)
 
-  private def parseHeaderHelp(header: String): JwtHeader = {
-    val cursor = parse(header).hcursor
-    JwtHeader(
-      algorithm = getAlg(cursor),
-      typ = cursor.get[String]("typ").toOption,
-      contentType = cursor.get[String]("cty").toOption,
-      keyId = cursor.get[String]("kid").toOption
-    )
+  private def parseHeaderHelp(header: String): Try[JwtHeader] = {
+    parse(header).map(_.hcursor).map { cursor =>
+      JwtHeader(
+        algorithm = getAlg(cursor),
+        typ = cursor.get[String]("typ").toOption,
+        contentType = cursor.get[String]("cty").toOption,
+        keyId = cursor.get[String]("kid").toOption
+      )
+    }
   }
 
   @nowarn // The cats import is necessary for 2.12 but not for 2.13, causing a warning
-  private def parseClaimHelp(claim: String): JwtClaim = {
+  private def parseClaimHelp(claim: String): Try[JwtClaim] = {
     import cats.syntax.either._
 
-    val cursor = parse(claim).hcursor
-    val contentCursor = List("iss", "sub", "aud", "exp", "nbf", "iat", "jti").foldLeft(cursor) {
-      (cursor, field) =>
-        cursor.downField(field).delete.success match {
-          case Some(newCursor) => newCursor
-          case None            => cursor
+    parse(claim).map(_.hcursor).map { cursor =>
+      val contentCursor =
+        List("iss", "sub", "aud", "exp", "nbf", "iat", "jti").foldLeft(cursor) { (cursor, field) =>
+          cursor.downField(field).delete.success match {
+            case Some(newCursor) => newCursor
+            case None            => cursor
+          }
         }
+      JwtClaim(
+        content = contentCursor.top.asJson.noSpaces,
+        issuer = cursor.get[String]("iss").toOption,
+        subject = cursor.get[String]("sub").toOption,
+        audience = cursor
+          .get[Set[String]]("aud")
+          .orElse(cursor.get[String]("aud").map(s => Set(s)))
+          .toOption,
+        expiration = cursor.get[Long]("exp").toOption,
+        notBefore = cursor.get[Long]("nbf").toOption,
+        issuedAt = cursor.get[Long]("iat").toOption,
+        jwtId = cursor.get[String]("jti").toOption
+      )
     }
-    JwtClaim(
-      content = contentCursor.top.asJson.noSpaces,
-      issuer = cursor.get[String]("iss").toOption,
-      subject = cursor.get[String]("sub").toOption,
-      audience =
-        cursor.get[Set[String]]("aud").orElse(cursor.get[String]("aud").map(s => Set(s))).toOption,
-      expiration = cursor.get[Long]("exp").toOption,
-      notBefore = cursor.get[Long]("nbf").toOption,
-      issuedAt = cursor.get[Long]("iat").toOption,
-      jwtId = cursor.get[String]("jti").toOption
-    )
   }
 }
 
 class JwtCirce private (override val clock: Clock) extends JwtCirceParser[JwtHeader, JwtClaim] {
   import JwtCirce.{parseHeaderHelp, parseClaimHelp}
 
-  def parseHeader(header: String): JwtHeader = parseHeaderHelp(header)
+  def parseHeader(header: String): Try[JwtHeader] = parseHeaderHelp(header)
 
-  def parseClaim(claim: String): JwtClaim = parseClaimHelp(claim)
+  def parseClaim(claim: String): Try[JwtClaim] = parseClaimHelp(claim)
 }

--- a/json/common/src/main/scala/JwtJsonCommon.scala
+++ b/json/common/src/main/scala/JwtJsonCommon.scala
@@ -12,7 +12,7 @@ import pdi.jwt.exceptions.{
 }
 
 trait JwtJsonCommon[J, H, C] extends JwtCore[H, C] {
-  protected def parse(value: String): J
+  protected def parse(value: String): Try[J]
   protected def stringify(value: J): String
   protected def getAlgorithm(header: J): Option[JwtAlgorithm]
 
@@ -53,8 +53,11 @@ trait JwtJsonCommon[J, H, C] extends JwtCore[H, C] {
   def encode(claim: J, key: PrivateKey, algorithm: JwtAsymmetricAlgorithm): String =
     encode(stringify(claim), key, algorithm)
 
-  def decodeJsonAll(token: String, options: JwtOptions): Try[(J, J, String)] =
-    decodeRawAll(token, options).map { tuple => (parse(tuple._1), parse(tuple._2), tuple._3) }
+  def decodeJsonAll(token: String, options: JwtOptions): Try[(J, J, String)] = for {
+    (header, claim, signature) <- decodeRawAll(token, options)
+    headerJson <- parse(header)
+    claimJson <- parse(claim)
+  } yield (headerJson, claimJson, signature)
 
   def decodeJsonAll(token: String): Try[(J, J, String)] =
     decodeJsonAll(token, JwtOptions.DEFAULT)
@@ -64,10 +67,11 @@ trait JwtJsonCommon[J, H, C] extends JwtCore[H, C] {
       key: String,
       algorithms: Seq[JwtHmacAlgorithm],
       options: JwtOptions
-  ): Try[(J, J, String)] =
-    decodeRawAll(token, key, algorithms, options).map { tuple =>
-      (parse(tuple._1), parse(tuple._2), tuple._3)
-    }
+  ): Try[(J, J, String)] = for {
+    (header, claim, signature) <- decodeRawAll(token, key, algorithms, options)
+    headerJson <- parse(header)
+    claimJson <- parse(claim)
+  } yield (headerJson, claimJson, signature)
 
   def decodeJsonAll(
       token: String,
@@ -81,10 +85,11 @@ trait JwtJsonCommon[J, H, C] extends JwtCore[H, C] {
       key: String,
       algorithms: => Seq[JwtAsymmetricAlgorithm],
       options: JwtOptions
-  ): Try[(J, J, String)] =
-    decodeRawAll(token, key, algorithms, options).map { tuple =>
-      (parse(tuple._1), parse(tuple._2), tuple._3)
-    }
+  ): Try[(J, J, String)] = for {
+    (header, claim, signature) <- decodeRawAll(token, key, algorithms, options)
+    headerJson <- parse(header)
+    claimJson <- parse(claim)
+  } yield (headerJson, claimJson, signature)
 
   def decodeJsonAll(
       token: String,
@@ -98,10 +103,11 @@ trait JwtJsonCommon[J, H, C] extends JwtCore[H, C] {
       key: SecretKey,
       algorithms: Seq[JwtHmacAlgorithm],
       options: JwtOptions
-  ): Try[(J, J, String)] =
-    decodeRawAll(token, key, algorithms, options).map { tuple =>
-      (parse(tuple._1), parse(tuple._2), tuple._3)
-    }
+  ): Try[(J, J, String)] = for {
+    (header, claim, signature) <- decodeRawAll(token, key, algorithms, options)
+    headerJson <- parse(header)
+    claimJson <- parse(claim)
+  } yield (headerJson, claimJson, signature)
 
   def decodeJsonAll(
       token: String,
@@ -121,10 +127,11 @@ trait JwtJsonCommon[J, H, C] extends JwtCore[H, C] {
       key: PublicKey,
       algorithms: Seq[JwtAsymmetricAlgorithm],
       options: JwtOptions
-  ): Try[(J, J, String)] =
-    decodeRawAll(token, key, algorithms, options).map { tuple =>
-      (parse(tuple._1), parse(tuple._2), tuple._3)
-    }
+  ): Try[(J, J, String)] = for {
+    (header, claim, signature) <- decodeRawAll(token, key, algorithms, options)
+    headerJson <- parse(header)
+    claimJson <- parse(claim)
+  } yield (headerJson, claimJson, signature)
 
   def decodeJsonAll(
       token: String,

--- a/json/json4s-jackson/src/main/scala/JwtJson4sImplicits.scala
+++ b/json/json4s-jackson/src/main/scala/JwtJson4sImplicits.scala
@@ -4,10 +4,10 @@ import org.json4s.JValue
 
 trait JwtJson4sImplicits {
   implicit class RichJwtClaim(claim: JwtClaim) {
-    def toJValue(): JValue = JwtJson4s.writeClaim(claim)
+    def toJValue(): JValue = JwtJson4s.writeClaim(claim).get
   }
 
   implicit class RichJwtHeader(header: JwtHeader) {
-    def toJValue(): JValue = JwtJson4s.writeHeader(header)
+    def toJValue(): JValue = JwtJson4s.writeHeader(header).get
   }
 }

--- a/json/json4s-jackson/src/main/scala/JwtJson4sJackson.scala
+++ b/json/json4s-jackson/src/main/scala/JwtJson4sJackson.scala
@@ -1,6 +1,7 @@
 package pdi.jwt
 
 import java.time.Clock
+import scala.util.{Failure, Try, Success}
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
 import org.json4s.jackson.JsonMethods.{parse => jparse}
@@ -11,9 +12,9 @@ import org.json4s.jackson.Serialization
   * To see a full list of samples, check the [[https://jwt-scala.github.io/jwt-scala/jwt-json4s.html online documentation]].
   */
 trait JwtJson4sParser[H, C] extends JwtJson4sCommon[H, C] with JwtJson4sImplicits {
-  protected def parse(value: String): JObject = jparse(value) match {
-    case res: JObject => res
-    case _            => throw new RuntimeException(s"Couldn't parse [$value] to a JObject")
+  protected def parse(value: String): Try[JObject] = Try(jparse(value)).flatMap {
+    case res: JObject => Success(res)
+    case _            => Failure(new RuntimeException(s"Couldn't parse [$value] to a JObject"))
   }
 
   protected def stringify(value: JObject): String = compact(render(value))
@@ -24,11 +25,11 @@ trait JwtJson4sParser[H, C] extends JwtJson4sCommon[H, C] with JwtJson4sImplicit
 
 object JwtJson4s extends JwtJson4sParser[JwtHeader, JwtClaim] {
   def apply(clock: Clock): JwtJson4s = new JwtJson4s(clock)
-  def parseHeader(header: String): JwtHeader = readHeader(parse(header))
-  def parseClaim(claim: String): JwtClaim = readClaim(parse(claim))
+  def parseHeader(header: String): Try[JwtHeader] = parse(header).flatMap(readHeader)
+  def parseClaim(claim: String): Try[JwtClaim] = parse(claim).flatMap(readClaim)
 }
 
 class JwtJson4s private (override val clock: Clock) extends JwtJson4sParser[JwtHeader, JwtClaim] {
-  def parseHeader(header: String): JwtHeader = readHeader(parse(header))
-  def parseClaim(claim: String): JwtClaim = readClaim(parse(claim))
+  def parseHeader(header: String): Try[JwtHeader] = parse(header).flatMap(readHeader)
+  def parseClaim(claim: String): Try[JwtClaim] = parse(claim).flatMap(readClaim)
 }

--- a/json/json4s-native/src/main/scala/JwtJson4sImplicits.scala
+++ b/json/json4s-native/src/main/scala/JwtJson4sImplicits.scala
@@ -4,10 +4,10 @@ import org.json4s.JValue
 
 trait JwtJson4sImplicits {
   implicit class RichJwtClaim(claim: JwtClaim) {
-    def toJValue(): JValue = JwtJson4s.writeClaim(claim)
+    def toJValue(): JValue = JwtJson4s.writeClaim(claim).get
   }
 
   implicit class RichJwtHeader(header: JwtHeader) {
-    def toJValue(): JValue = JwtJson4s.writeHeader(header)
+    def toJValue(): JValue = JwtJson4s.writeHeader(header).get
   }
 }

--- a/json/play-json/src/main/scala/JwtJson.scala
+++ b/json/play-json/src/main/scala/JwtJson.scala
@@ -1,6 +1,7 @@
 package pdi.jwt
 
 import java.time.Clock
+import scala.util.Try
 import play.api.libs.json._
 import pdi.jwt.exceptions.JwtNonStringException
 
@@ -9,7 +10,7 @@ import pdi.jwt.exceptions.JwtNonStringException
   * To see a full list of samples, check the [[https://jwt-scala.github.io/jwt-scala/jwt-play-json.html online documentation]].
   */
 trait JwtJsonParser[H, C] extends JwtJsonCommon[JsObject, H, C] with JwtJsonImplicits {
-  protected def parse(value: String): JsObject = Json.parse(value).as[JsObject]
+  protected def parse(value: String): Try[JsObject] = Try(Json.parse(value).as[JsObject])
 
   protected def stringify(value: JsObject): String = Json.stringify(value)
 
@@ -25,11 +26,19 @@ trait JwtJsonParser[H, C] extends JwtJsonCommon[JsObject, H, C] with JwtJsonImpl
 
 object JwtJson extends JwtJsonParser[JwtHeader, JwtClaim] {
   def apply(clock: Clock): JwtJson = new JwtJson(clock)
-  def parseHeader(header: String): JwtHeader = jwtPlayJsonHeaderReader.reads(Json.parse(header)).get
-  def parseClaim(claim: String): JwtClaim = jwtPlayJsonClaimReader.reads(Json.parse(claim)).get
+  def parseHeader(header: String): Try[JwtHeader] = Try(
+    jwtPlayJsonHeaderReader.reads(Json.parse(header)).get
+  )
+  def parseClaim(claim: String): Try[JwtClaim] = Try(
+    jwtPlayJsonClaimReader.reads(Json.parse(claim)).get
+  )
 }
 
 class JwtJson private (override val clock: Clock) extends JwtJsonParser[JwtHeader, JwtClaim] {
-  def parseHeader(header: String): JwtHeader = jwtPlayJsonHeaderReader.reads(Json.parse(header)).get
-  def parseClaim(claim: String): JwtClaim = jwtPlayJsonClaimReader.reads(Json.parse(claim)).get
+  def parseHeader(header: String): Try[JwtHeader] = Try(
+    jwtPlayJsonHeaderReader.reads(Json.parse(header)).get
+  )
+  def parseClaim(claim: String): Try[JwtClaim] = Try(
+    jwtPlayJsonClaimReader.reads(Json.parse(claim)).get
+  )
 }

--- a/json/upickle/src/main/scala/JwtUpickle.scala
+++ b/json/upickle/src/main/scala/JwtUpickle.scala
@@ -1,6 +1,7 @@
 package pdi.jwt
 
 import java.time.Clock
+import scala.util.Try
 import upickle.default._
 
 /** Implementation of `JwtCore` using `Js.Value` from uPickle.
@@ -8,7 +9,7 @@ import upickle.default._
   * To see a full list of samples, check the [[https://jwt-scala.github.io/jwt-scala/jwt-upickle.html online documentation]].
   */
 trait JwtUpickleParser[H, C] extends JwtJsonCommon[ujson.Value, H, C] with JwtUpickleImplicits {
-  protected def parse(value: String): ujson.Value = ujson.read(value)
+  protected def parse(value: String): Try[ujson.Value] = Try(ujson.read(value))
 
   protected def stringify(value: ujson.Value): String = ujson.write(value)
 
@@ -23,11 +24,11 @@ trait JwtUpickleParser[H, C] extends JwtJsonCommon[ujson.Value, H, C] with JwtUp
 
 object JwtUpickle extends JwtUpickleParser[JwtHeader, JwtClaim] {
   def apply(clock: Clock): JwtUpickle = new JwtUpickle(clock)
-  def parseHeader(header: String): JwtHeader = read[JwtHeader](header)
-  def parseClaim(claim: String): JwtClaim = read[JwtClaim](claim)
+  def parseHeader(header: String): Try[JwtHeader] = Try(read[JwtHeader](header))
+  def parseClaim(claim: String): Try[JwtClaim] = Try(read[JwtClaim](claim))
 }
 
 class JwtUpickle private (override val clock: Clock) extends JwtUpickleParser[JwtHeader, JwtClaim] {
-  def parseHeader(header: String): JwtHeader = read[JwtHeader](header)
-  def parseClaim(claim: String): JwtClaim = read[JwtClaim](claim)
+  def parseHeader(header: String): Try[JwtHeader] = Try(read[JwtHeader](header))
+  def parseClaim(claim: String): Try[JwtClaim] = Try(read[JwtClaim](claim))
 }


### PR DESCRIPTION
This is an attempt to make the codebase more functional by removing `throw` statements as much as possible, and work with `Try[_]` instead of having a bunch of functions that throw and a `Try` at the very top.

This PR addresses the decoding part. It changes the signature of some public functions (like all the `validate`). Most people shouldn't be using them too much anyway but it's still a breaking change that might force users to adapt their code when upgrading.

Encode still throws a lot, that would be a separate work.

As it's an important change, I'm open to feedback and discussion, I won't be merging it right away.