### PR TITLE
fix: allow dashes in subject

### DIFF
--- a/core/src/main/scala/Jwt.scala
+++ b/core/src/main/scala/Jwt.scala
@@ -29,7 +29,7 @@ object Jwt extends JwtCore[JwtHeader, JwtClaim] {
   protected def extractIssuer(claim: String): Option[String] =
     (extractIssuerRegex findFirstMatchIn claim).map(_.group(1))
 
-  private val extractSubjectRegex = "\"sub\" *: *\"([a-zA-Z0-9]*)\"".r
+  private val extractSubjectRegex = "\"sub\" *: *\"([\\-a-zA-Z0-9]*)\"".r
   protected def extractSubject(claim: String): Option[String] =
     (extractSubjectRegex findFirstMatchIn claim).map(_.group(1))
 

--- a/core/src/test/scala/JwtSpec.scala
+++ b/core/src/test/scala/JwtSpec.scala
@@ -25,6 +25,13 @@ class JwtSpec extends munit.FunSuite with Fixture {
     assert(Jwt.isValid(tokenWithSpaces))
   }
 
+  test("should decode subject with dashes") {
+    Jwt.decode(validTimeJwt.encode(s"""{"sub":"das-hed"""")) match {
+      case Success(jwt) => assertEquals(jwt.subject, Option("das-hed"))
+      case _ => fail("failed decoding token")
+    }
+  }
+
   test("should encode Hmac") {
     data.foreach { d => battleTestEncode(d, secretKey, validTimeJwt) }
   }


### PR DESCRIPTION
A dash in subject results in a None in decoded token - this is surprising behaviour, and doesn't allow for uuid subjects for example.