### PR TITLE
Use EdDSA instead of Ed25519

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Check [ECDSA samples](https://jwt-scala.github.io/jwt-scala/jwt-core-jwt-ecdsa.h
 |ES256|ECDSA using SHA-256 algorithm|
 |ES384|ECDSA using SHA-384 algorithm|
 |ES512|ECDSA using SHA-512 algorithm|
-|Ed25519|EdDSA using SHA-512 and Curve25519|
+|EdDSA|EdDSA signature algorithms|
 
 ## Security concerns
 

--- a/core/shared/src/main/scala/JwtAlgorithm.scala
+++ b/core/shared/src/main/scala/JwtAlgorithm.scala
@@ -1,5 +1,7 @@
 package pdi.jwt
 
+import scala.annotation.nowarn
+
 import pdi.jwt.algorithms.JwtUnknownAlgorithm
 
 sealed trait JwtAlgorithm {
@@ -31,6 +33,7 @@ object JwtAlgorithm {
     * @throws JwtNonSupportedAlgorithm
     *   in case the string doesn't match any known algorithm
     */
+  @nowarn("cat=deprecation")
   def fromString(algo: String): JwtAlgorithm = algo match {
     case "HMD5"    => HMD5
     case "HS224"   => HS224
@@ -43,6 +46,7 @@ object JwtAlgorithm {
     case "ES256"   => ES256
     case "ES384"   => ES384
     case "ES512"   => ES512
+    case "EdDSA"   => EdDSA
     case "Ed25519" => Ed25519
     case other     => JwtUnknownAlgorithm(other)
     // Missing PS256 PS384 PS512
@@ -61,14 +65,16 @@ object JwtAlgorithm {
 
   def allHmac(): Seq[algorithms.JwtHmacAlgorithm] = Seq(HMD5, HS224, HS256, HS384, HS512)
 
+  @nowarn("cat=deprecation")
   def allAsymmetric(): Seq[algorithms.JwtAsymmetricAlgorithm] =
-    Seq(RS256, RS384, RS512, ES256, ES384, ES512, Ed25519)
+    Seq(RS256, RS384, RS512, ES256, ES384, ES512, EdDSA, Ed25519)
 
   def allRSA(): Seq[algorithms.JwtRSAAlgorithm] = Seq(RS256, RS384, RS512)
 
   def allECDSA(): Seq[algorithms.JwtECDSAAlgorithm] = Seq(ES256, ES384, ES512)
 
-  def allEdDSA(): Seq[algorithms.JwtEdDSAAlgorithm] = Seq(Ed25519)
+  @nowarn("cat=deprecation")
+  def allEdDSA(): Seq[algorithms.JwtEdDSAAlgorithm] = Seq(EdDSA, Ed25519)
 
   case object HMD5 extends algorithms.JwtHmacAlgorithm {
     def name = "HMD5"; def fullName = "HmacMD5"
@@ -103,6 +109,10 @@ object JwtAlgorithm {
   case object ES512 extends algorithms.JwtECDSAAlgorithm {
     def name = "ES512"; def fullName = "SHA512withECDSA"
   }
+  case object EdDSA extends algorithms.JwtEdDSAAlgorithm {
+    def name = "EdDSA"; def fullName = "EdDSA"
+  }
+  @deprecated("Ed25519 is not a standard Json Web Algorithm name. Use EdDSA instead.", "9.3.0")
   case object Ed25519 extends algorithms.JwtEdDSAAlgorithm {
     def name = "Ed25519"; def fullName = "Ed25519"
   }

--- a/core/shared/src/test/scala/Fixture.scala
+++ b/core/shared/src/test/scala/Fixture.scala
@@ -262,11 +262,11 @@ b5VoYLNsdvZhqjVFTrYNEuhTJFYCF7jAiZLYvYm0C99BqcJnJPl7JjWynoNHNKw3
 
   val dataEdDSA = Seq(
     DataEntry(
-      JwtAlgorithm.Ed25519,
-      """{"typ":"JWT","alg":"Ed25519"}""",
-      JwtHeader(JwtAlgorithm.Ed25519, "JWT"),
-      "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZDI1NTE5In0",
-      "Y1L7qIIxk022Bi6RfybVXRI1YrTmchD8gc6ExiGFoHMyNTamrmsbRQi7EHF2ha4vSvuK8cFH2e89k4c8T0eGBA"
+      JwtAlgorithm.EdDSA,
+      """{"typ":"JWT","alg":"EdDSA"}""",
+      JwtHeader(JwtAlgorithm.EdDSA, "JWT"),
+      "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSJ9",
+      "I4phqhsuywTyv0Fb12v0X-ILw8tFdDlDExRTsBUYMB2yjo340KXC8L_QfUyO7-8NoMzO5k4rHPkxq8cC2xu8CQ"
     )
   ).map(setToken)
 }

--- a/core/shared/src/test/scala/JwtSpec.scala
+++ b/core/shared/src/test/scala/JwtSpec.scala
@@ -40,7 +40,7 @@ class JwtSpec extends munit.FunSuite with Fixture {
     dataRSA.foreach { d => battleTestEncode(d, privateKeyRSA, validTimeJwt) }
   }
 
-  test("should encode Ed25519") {
+  test("should encode EdDSA") {
     dataEdDSA.foreach { d => battleTestEncode(d, privateKeyEd25519, validTimeJwt) }
   }
 


### PR DESCRIPTION
Fixes #464.

`Ed25519` is not a valid [Json Web Algorithm](https://www.rfc-editor.org/rfc/rfc7518#section-6.2) name.  It is the name of a curve used when the `EdDSA` algorithm is in use, and in that instance, `EdDSA` is the correct algorithm name to use. `Ed25519` is just a property of the private key, alternate curves can also be used, such as `Ed448`, the use of these curves don't impact the algorithm being used.