### PR TITLE
Issue #472: Improve parsing of RSA keys

### DIFF
--- a/core/jvm/src/test/scala/JwtSpec.scala
+++ b/core/jvm/src/test/scala/JwtSpec.scala
@@ -226,6 +226,19 @@ class JwtSpec extends munit.FunSuite with Fixture {
     }
   }
 
+  def oneLine(key: String) = key.replaceAll("\r\n", " ").replaceAll("\n", " ")
+
+  test("should validate using RSA keys converted to single line") {
+    val pubKey = oneLine(publicKeyRSA)
+    dataRSA.foreach { d =>
+      assertEquals(
+        (),
+        validTimeJwt.validate(d.token, pubKey, JwtAlgorithm.allRSA()),
+        d.algo.fullName
+      )
+    }
+  }
+
   test("should validate ECDSA from other implementations") {
     val publicKey =
       "MIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQASisgweVL1tAtIvfmpoqvdXF8sPKTV9YTKNxBwkdkm+/auh4pR8TbaIfsEzcsGUVv61DFNFXb0ozJfurQ59G2XcgAn3vROlSSnpbIvuhKrzL5jwWDTaYa5tVF1Zjwia/5HUhKBkcPuWGXg05nMjWhZfCuEetzMLoGcHmtvabugFrqsAg="

--- a/core/shared/src/main/scala/JwtUtils.scala
+++ b/core/shared/src/main/scala/JwtUtils.scala
@@ -90,12 +90,7 @@ object JwtUtils {
   }
 
   private def parseKey(key: String): Array[Byte] = JwtBase64.decodeNonSafe(
-    key
-      .replaceAll("-----BEGIN (.*)-----", "")
-      .replaceAll("-----END (.*)-----", "")
-      .replaceAll("\r\n", "")
-      .replaceAll("\n", "")
-      .trim
+    key.replaceAll("-----BEGIN ([^-]*)-----|-----END ([^-]*)-----|\\s*", "")
   )
 
   private def parsePrivateKey(key: String, keyAlgo: String) = {


### PR DESCRIPTION
As explained in #472 , parseKey contains a bug, exposed when the RSA key has been converted to a 1 line format. My added test fails using the old version of parseKey, all tests pass with my new version.