### PR TITLE
Update Scala Native to `0.5.5`

### DIFF
--- a/project/Libs.scala
+++ b/project/Libs.scala
@@ -2,13 +2,13 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 import sbt._
 
 object Versions {
-  val munit = "1.0.0-M11"
+  val munit = "1.0.0"
 
   val bouncyCastle = "1.78.1"
 
   val guice = "4.2.3"
 
-  val scalaJavaTime = "2.5.0"
+  val scalaJavaTime = "2.6.0"
 
   val scalajsSecureRandom = "1.0.0"
 
@@ -18,9 +18,9 @@ object Versions {
 
   val json4s = "4.0.7"
 
-  val circe = "0.14.8"
+  val circe = "0.14.10"
 
-  val upickle = "3.1.4"
+  val upickle = "3.3.1"
 
   val zioJson = "0.7.3"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -30,7 +30,7 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.3")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.17.0")
 
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.17")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.5")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
 


### PR DESCRIPTION
Update scala-java-time to `2.6.0`
Update munit to `1.0.0`
Update circe to `0.14.10`
Update upickle to `3.3.1`

Now [scala-native-crypto](https://github.com/lolgab/scala-native-crypto) provides a minimum set of classes so [jwt-scala works](https://github.com/lolgab/scala-native-crypto/pull/20/files#diff-06776b6ddb76c98da94c190bfb0961ff6d489ff64dfbd80b00977b46580a56f3R11-R41)
But it is released for Scala Native 0.5, so we need an update on jwt-scala to make use of it.