### PR TITLE
allow underscore in sub

### DIFF
--- a/core/jvm/src/test/scala/JwtSpec.scala
+++ b/core/jvm/src/test/scala/JwtSpec.scala
@@ -24,9 +24,16 @@ class JwtSpec extends munit.FunSuite with Fixture {
     assert(Jwt.isValid(tokenWithSpaces))
   }
 
-  test("should decode subject with dashes") {
-    Jwt.decode(validTimeJwt.encode(s"""{"sub":"das-hed"""")) match {
+  test("should decode subject with a dash") {
+    Jwt.decode(validTimeJwt.encode("""{"sub":"das-hed"""")) match {
       case Success(jwt) => assertEquals(jwt.subject, Option("das-hed"))
+      case _            => fail("failed decoding token")
+    }
+  }
+
+  test("should decode subject with an underscore") {
+    Jwt.decode(validTimeJwt.encode("""{"sub":"das_hed"""")) match {
+      case Success(jwt) => assertEquals(jwt.subject, Option("das_hed"))
       case _            => fail("failed decoding token")
     }
   }

--- a/core/shared/src/main/scala/Jwt.scala
+++ b/core/shared/src/main/scala/Jwt.scala
@@ -22,23 +22,18 @@ object Jwt extends Jwt(Clock.systemUTC) {
 }
 
 class Jwt(override val clock: Clock) extends JwtCore[JwtHeader, JwtClaim] {
-  // charsAndNums only allows alphanumeric characters (with no diacritics)
-  private val charsAndNums = "a-zA-Z0-9"
-  // charsAndNumsAndSomePunctuation adds `_` and `-` to charsAndNums
-  private val charsAndNumsAndSomePunctuation = s"\\-${charsAndNums}_"
-
-  private val extractAlgorithmRegex = s"\"alg\" *: *\"([$charsAndNums]+)\"".r
+  private val extractAlgorithmRegex = "\"alg\" *: *\"([a-zA-Z0-9]+)\"".r
   protected def extractAlgorithm(header: String): Option[JwtAlgorithm] =
     (extractAlgorithmRegex.findFirstMatchIn(header)).map(_.group(1)).flatMap {
       case "none"       => None
       case name: String => Some(JwtAlgorithm.fromString(name))
     }
 
-  private val extractIssuerRegex = s"\"iss\" *: *\"([$charsAndNumsAndSomePunctuation]*)\"".r
+  private val extractIssuerRegex = "\"iss\" *: *\"([\\-a-zA-Z0-9_]*)\"".r
   protected def extractIssuer(claim: String): Option[String] =
     (extractIssuerRegex.findFirstMatchIn(claim)).map(_.group(1))
 
-  private val extractSubjectRegex = s"\"sub\" *: *\"([$charsAndNumsAndSomePunctuation]*)\"".r
+  private val extractSubjectRegex = "\"sub\" *: *\"([\\-a-zA-Z0-9_]*)\"".r
   protected def extractSubject(claim: String): Option[String] =
     (extractSubjectRegex.findFirstMatchIn(claim)).map(_.group(1))
 
@@ -54,7 +49,7 @@ class Jwt(override val clock: Clock) extends JwtCore[JwtHeader, JwtClaim] {
   protected def extractIssuedAt(claim: String): Option[Long] =
     (extractIssuedAtRegex.findFirstMatchIn(claim)).map(_.group(1)).map(_.toLong)
 
-  private val extractJwtIdRegex = s"\"jti\" *: *\"([$charsAndNumsAndSomePunctuation]*)\"".r
+  private val extractJwtIdRegex = "\"jti\" *: *\"([\\-a-zA-Z0-9_]*)\"".r
   protected def extractJwtId(claim: String): Option[String] =
     (extractJwtIdRegex.findFirstMatchIn(claim)).map(_.group(1))
 

--- a/core/shared/src/main/scala/Jwt.scala
+++ b/core/shared/src/main/scala/Jwt.scala
@@ -22,18 +22,23 @@ object Jwt extends Jwt(Clock.systemUTC) {
 }
 
 class Jwt(override val clock: Clock) extends JwtCore[JwtHeader, JwtClaim] {
-  private val extractAlgorithmRegex = "\"alg\" *: *\"([a-zA-Z0-9]+)\"".r
+  // charsAndNums only allows alphanumeric characters (with no diacritics)
+  private val charsAndNums = "a-zA-Z0-9"
+  // charsAndNumsAndSomePunctuation adds `_` and `-` to charsAndNums
+  private val charsAndNumsAndSomePunctuation = s"\\-${charsAndNums}_"
+
+  private val extractAlgorithmRegex = s"\"alg\" *: *\"([$charsAndNums]+)\"".r
   protected def extractAlgorithm(header: String): Option[JwtAlgorithm] =
     (extractAlgorithmRegex.findFirstMatchIn(header)).map(_.group(1)).flatMap {
       case "none"       => None
       case name: String => Some(JwtAlgorithm.fromString(name))
     }
 
-  private val extractIssuerRegex = "\"iss\" *: *\"([\\-a-zA-Z0-9_]*)\"".r
+  private val extractIssuerRegex = s"\"iss\" *: *\"([$charsAndNumsAndSomePunctuation]*)\"".r
   protected def extractIssuer(claim: String): Option[String] =
     (extractIssuerRegex.findFirstMatchIn(claim)).map(_.group(1))
 
-  private val extractSubjectRegex = "\"sub\" *: *\"([\\-a-zA-Z0-9]*)\"".r
+  private val extractSubjectRegex = s"\"sub\" *: *\"([$charsAndNumsAndSomePunctuation]*)\"".r
   protected def extractSubject(claim: String): Option[String] =
     (extractSubjectRegex.findFirstMatchIn(claim)).map(_.group(1))
 
@@ -49,7 +54,7 @@ class Jwt(override val clock: Clock) extends JwtCore[JwtHeader, JwtClaim] {
   protected def extractIssuedAt(claim: String): Option[Long] =
     (extractIssuedAtRegex.findFirstMatchIn(claim)).map(_.group(1)).map(_.toLong)
 
-  private val extractJwtIdRegex = "\"jti\" *: *\"([\\-a-zA-Z0-9_]*)\"".r
+  private val extractJwtIdRegex = s"\"jti\" *: *\"([$charsAndNumsAndSomePunctuation]*)\"".r
   protected def extractJwtId(claim: String): Option[String] =
     (extractJwtIdRegex.findFirstMatchIn(claim)).map(_.group(1))
 


### PR DESCRIPTION
* relates to #649 
* jwt-scala already allows underscores in other claim data
* the JWT spec doesn't really go into detail about what chars are allowed but most blogs seem to recommend sticking to chars that don't need URL encoding
* this does not fix #619 