### PR TITLE
Update zio-json to 0.9.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ val previousVersion = "9.4.0"
 val buildVersion = "9.4.1"
 
 val scala212 = "2.12.20"
-val scala213 = "2.13.16"
+val scala213 = "2.13.18"
 val scala3 = "3.3.7"
 
 Global / onChangedBuildSource := ReloadOnSourceChanges

--- a/project/Libs.scala
+++ b/project/Libs.scala
@@ -22,7 +22,7 @@ object Versions {
 
   val upickle = "4.4.0"
 
-  val zioJson = "0.7.44"
+  val zioJson = "0.9.0"
 
   val argonaut = "6.3.10"
 }


### PR DESCRIPTION
## Summary
- Bump `zio-json` from `0.7.44` to `0.9.0`
- Bump Scala `2.13.16` to `2.13.18` (required by `zio-json` 0.9.0)

All `zioJson` module tests pass.